### PR TITLE
Refactor status load conditions

### DIFF
--- a/GridCore.lua
+++ b/GridCore.lua
@@ -223,10 +223,8 @@ function Grid2:PLAYER_SPECIALIZATION_CHANGED(event,unit)
 end
 
 function Grid2:PLAYER_ROLES_ASSIGNED()
-	self:RefreshStatusesFilter('unitRole')
-	if not self:ReloadTheme() then
-		self:SendMessage("Grid_PlayerRolesAssigned")
-	end
+	self:SendMessage("Grid_PlayerRolesAssigned")
+	self:ReloadTheme()
 end
 
 -- Themes

--- a/GridFrame.lua
+++ b/GridFrame.lua
@@ -171,9 +171,11 @@ function GridFramePrototype:Layout()
 		self:SetHighlightTexture( Grid2:MediaFetch("background", dbx.mouseoverTexture, "Blizzard Quest Title Highlight") )
 		local color = dbx.mouseoverColor
 		self:GetHighlightTexture():SetVertexColor(color.r, color.g, color.b, color.a)
-	else
+	elseif self:GetHighlightTexture() then
 		self:SetHighlightTexture('')
+		self:GetHighlightTexture():SetVertexColor(0,0,0,0) 
 	end
+	-- self:GetHighlightTexture():SetVertexColor(0,0,0,0)
 	-- Adjust indicators position to the new size
 	local indicators = Grid2:GetIndicatorsEnabled()
 	for i=1,#indicators do

--- a/GridIndicator.lua
+++ b/GridIndicator.lua
@@ -46,6 +46,8 @@ end
 function indicator:Release(parent)
 	local f = parent[self.name]
 	if f then
+		local Destroy = self.Destroy
+		if Destroy then Destroy(self, parent, f) end
 		f:SetParent(nil)
 		f:ClearAllPoints()
 		f:Hide()

--- a/GridStatus.lua
+++ b/GridStatus.lua
@@ -58,13 +58,9 @@ status.OnEnable = Grid2.Dummy
 -- all indicators
 status.OnDisable = Grid2.Dummy
 -- all indicators
-status.Refresh = Grid2.Dummy
+status.UpdateDB = Grid2.Dummy
 -- all indicators
 status.UpdateAllUnits = Grid2.statusLibrary.UpdateAllUnits
-
-function status:UpdateDB(dbx)
-	if dbx then	self.dbx = dbx end
-end
 
 function status:Inject(data)
 	for k,f in next, data do
@@ -87,7 +83,9 @@ function status:RegisterIndicator(indicator, priority, suspended)
 			local enabled = next(self.indicators)
 			self.indicators[indicator] = true
 			if not enabled then
-				self.enabled = true
+				self:UpdateDB() -- self.enabled must be false when calling UpdateDB()
+				self.enabled = true 
+				self:RegisterLoad()
 				self:OnEnable()
 			end
 		end
@@ -104,6 +102,7 @@ function status:UnregisterIndicator(indicator, priority)
 		if not enabled then
 			self.enabled = nil
 			self:OnDisable()
+			self:UnregisterLoad()
 		end
 	end
 end
@@ -120,7 +119,7 @@ function Grid2:RegisterStatus(status, types, baseKey, dbx)
 		t[#t+1] = status
 	end
 	status.dbx = dbx
-	status:RegisterLoad()
+	status:UpdateDB()
 end
 
 function Grid2:UnregisterStatus(status)
@@ -142,7 +141,6 @@ function Grid2:UnregisterStatus(status)
 			end
 		end
 	end
-	status:UnregisterLoad()
 end
 
 function Grid2:GetStatusByName(name)

--- a/GridStatusLoad.lua
+++ b/GridStatusLoad.lua
@@ -211,9 +211,16 @@ do
 	end
 
 	function FilterU_RefreshStatus(self, load)
+		local enabled = self.enabled
+		if enabled then 
+			self.enabled = nil
+			self:OnDisable() 
+		end
 		self:UpdateLoad()
 		self:UpdateDB()
-		if self.enabled then
+		if enabled then 
+			self.enabled = true
+			self:OnEnable() 
 			FilterU_RegisterStatus(self, load)
 			self:UpdateAllUnits()
 		end

--- a/GridStatusLoad.lua
+++ b/GridStatusLoad.lua
@@ -313,7 +313,7 @@ function status:UnregisterLoad() -- called from status:UnregisterIndicator()
 	if load then
 		FilterG_UnregisterStatus(self, load)
 		FilterU_UnregisterStatus(self, load)
-		FilterC_UnregisterSattus(self, load)
+		FilterC_UnregisterStatus(self, load)
 	end
 end
 

--- a/GridStatusLoad.lua
+++ b/GridStatusLoad.lua
@@ -1,144 +1,154 @@
 -- Statuses Load filter management, by MiCHaEL
 local Grid2 = Grid2
 local Grid2Frame = Grid2Frame
-local pairs = pairs
 local next = next
+local pairs = pairs
+local UnitClass = UnitClass
+local UnitExists = UnitExists
+local UnitIsFriend = UnitIsFriend
+local UnitGroupRolesAssigned = Grid2.UnitGroupRolesAssigned
+local roster_types = Grid2.roster_types
 
--- local variables
-local indicators = {} -- indicators marked for update
-local registered = {} -- registered messages
-local statuses   = { playerClassSpec = {}, groupInstType = {}, instNameID = {}, unitFilter = {} }
+-----------------------------------------------------------------------
+-- General filters: class/spec/zone/group type
+-- statuses are suspended&unregistered from indicators
+-----------------------------------------------------------------------
 
--- local functions
-local function RegisterMessage(message, enabled)
-	if not enabled ~= not registered[message] then
-		registered[message] = not not enabled
-		if enabled then
-			Grid2:RegisterMessage(message)
+local FilterG_RegisterStatus, FilterG_UnregisterStatus, FilterG_RefreshStatus
+do
+	-- local variables
+	local indicators = {} -- indicators marked for update
+	local registered = {} -- registered messages
+	local statuses   = { playerClassSpec = {}, groupInstType = {}, instNameID = {} }
+
+	-- local functions
+	local function RegisterMessage(message, enabled)
+		if not enabled ~= not registered[message] then
+			registered[message] = not not enabled
+			if enabled then
+				Grid2:RegisterMessage(message)
+			else
+				Grid2:UnregisterMessage(message)
+			end
+		end
+	end
+
+	local function UpdateMessages(status, load)
+		statuses.playerClassSpec[status] = load and load.playerClassSpec~=nil or nil
+		statuses.instNameID[status] = load and load.instNameID~=nil or nil
+		statuses.groupInstType[status] = load and (load.groupType~=nil or load.instType~=nil) or nil
+		RegisterMessage( "Grid_GroupTypeChanged",  next(statuses.groupInstType) )
+		RegisterMessage( "Grid_PlayerSpecChanged", next(statuses.playerClassSpec) )
+		RegisterMessage( "Grid_ZoneChangedNewArea", next(statuses.instNameID) )
+	end
+
+	local function RegisterIndicators(self)
+		local suspended = self.suspended
+		local method = suspended and "UnregisterStatus" or "RegisterStatus"
+		for indicator, priority in pairs(self.priorities) do -- register/unregister indicators
+			indicator[method](indicator, self, priority)
+			indicators[indicator] = true
+		end
+		if suspended then
+			wipe(self.filtered).source = self.dbx.load
+		elseif self.OnWakeUp then
+			self:OnWakeUp() 
+		end
+	end
+
+	local function UpdateIndicators()
+		for frame, unit in next, Grid2Frame.activatedFrames do
+			for indicator in next, indicators do
+				indicator:Update(frame, unit)
+			end
+		end
+		wipe(indicators)
+	end
+
+	local function CheckZoneFilter(filter)
+		local instanceName,_,_,_,_,_,_,instanceID = GetInstanceInfo()
+		return filter[instanceName] or filter[instanceID]
+	end
+
+	local function UpdateStatus(self)
+		local prev = self.suspended
+		local load = self.dbx.load
+		if load then
+			self.suspended =
+				( load.disabled ) or
+				( load.playerClass     and not load.playerClass[ Grid2.playerClass ]         ) or
+				( load.playerClassSpec and not load.playerClassSpec[ Grid2.playerClassSpec ] ) or
+				( load.groupType       and not load.groupType[ Grid2.groupType ]             ) or
+				( load.instType        and not load.instType[ Grid2.instType ]               ) or
+				( load.instNameID      and not CheckZoneFilter(load.instNameID)              ) or nil
+			return self.suspended ~= prev
 		else
-			Grid2:UnregisterMessage(message)
+			self.suspended = nil
+			return prev
 		end
 	end
-end
 
-local function UpdateMessages(status, load)
-	statuses.playerClassSpec[status] = load and load.playerClassSpec~=nil or nil
-	statuses.instNameID[status] = load and load.instNameID~=nil or nil
-	statuses.groupInstType[status] = load and (load.groupType~=nil or load.instType~=nil) or nil
-	RegisterMessage( "Grid_GroupTypeChanged",  next(statuses.groupInstType) )
-	RegisterMessage( "Grid_PlayerSpecChanged", next(statuses.playerClassSpec) )
-	RegisterMessage( "Grid_ZoneChangedNewArea", next(statuses.instNameID) )
-end
-
-local function RegisterIndicators(self)
-	local method = self.suspended and "UnregisterStatus" or "RegisterStatus"
-	for indicator, priority in pairs(self.priorities) do -- register/unregister indicators
-		indicator[method](indicator, self, priority)
-		indicators[indicator] = true
-	end
-	if not self.suspended then
-		self:Refresh() -- needed by aura statuses, to fill status cache with units aura info
-	end
-end
-
-local function UpdateIndicators()
-	for frame, unit in next, Grid2Frame.activatedFrames do
-		for indicator in next, indicators do
-			indicator:Update(frame, unit)
+	local function RefreshStatus(self)
+		if UpdateStatus(self) then
+			RegisterIndicators(self)
+			UpdateIndicators()
+			return true
 		end
 	end
-	wipe(indicators)
-end
 
-local function CheckZoneFilter(filter)
-	local instanceName,_,_,_,_,_,_,instanceID = GetInstanceInfo()
-	return filter[instanceName] or filter[instanceID]
-end
-
-local function UpdateStatus(self)
-	local prev = self.suspended
-	local load = self.dbx.load
-	if load then
-		self.suspended =
-			( load.disabled ) or
-			( load.playerClass     and not load.playerClass[ Grid2.playerClass ]         ) or
-			( load.playerClassSpec and not load.playerClassSpec[ Grid2.playerClassSpec ] ) or
-			( load.groupType       and not load.groupType[ Grid2.groupType ]             ) or
-			( load.instType        and not load.instType[ Grid2.instType ]               ) or
-			( load.instNameID      and not CheckZoneFilter(load.instNameID)              ) or nil
-		return self.suspended ~= prev
-	else
-		self.suspended = nil
-		return prev
-	end
-end
-
-local function RefreshStatus(self)
-	if UpdateStatus(self) then
-		RegisterIndicators(self)
+	local function RefreshStatuses(filterType)
+		local notify
+		for status in pairs(statuses[filterType]) do
+			if UpdateStatus(status) then
+				RegisterIndicators(status)
+				notify = true
+			end
+		end
 		UpdateIndicators()
-		return true
-	end
-end
-
-local function RefreshStatuses(filterType)
-	local notify
-	for status in pairs(statuses[filterType]) do
-		if UpdateStatus(status) then
-			RegisterIndicators(status)
-			notify = true
+		if notify then
+			Grid2:SendMessage("Grid_StatusLoadChanged")
 		end
 	end
-	UpdateIndicators()
-	if notify then
-		Grid2:SendMessage("Grid_StatusLoadChanged")
+
+	-- message events
+	function Grid2:Grid_GroupTypeChanged()
+		RefreshStatuses('groupInstType')
 	end
-end
 
--- message events
-function Grid2:Grid_GroupTypeChanged()
-	RefreshStatuses('groupInstType')
-end
+	function Grid2:Grid_PlayerSpecChanged()
+		RefreshStatuses('playerClassSpec')
+	end
 
-function Grid2:Grid_PlayerSpecChanged()
-	RefreshStatuses('playerClassSpec')
-end
-
-function Grid2:Grid_ZoneChangedNewArea()
-	RefreshStatuses('instNameID')
-end
-
--- status methods
-local status = Grid2.statusPrototype
-
-function status:RegisterLoad()
-	local load = self.dbx and self.dbx.load
-	if load then
+	function Grid2:Grid_ZoneChangedNewArea()
+		RefreshStatuses('instNameID')
+	end
+	
+	-- public 
+	function FilterG_RegisterStatus(self, load)
 		UpdateMessages(self, load)
 		UpdateStatus(self)
 	end
-end
 
-function status:UnregisterLoad()
-	if self.dbx and self.dbx.load then
-		UpdateMessages(self)
+	function FilterG_UnregisterStatus(self)
+		UpdateMessages(self, nil)
 	end
+
+	function FilterG_RefreshStatus(self, load)
+		UpdateMessages(self, load)
+		return RefreshStatus(self)
+	end
+
 end
 
-function status:RefreshLoad() -- used by options
-	UpdateMessages(self, self.dbx and self.dbx.load)
-	return RefreshStatus(self)
-end
+-----------------------------------------------------------------------
+-- Unit filters: type/class/role/reaction
+-- code check in :IsActive() method is necessary 
+-----------------------------------------------------------------------
 
------------------------------------------------------
--- Unit filters management: type/class/role/reaction
------------------------------------------------------
+local FilterU_RegisterStatus, FilterU_UnregisterStatus, FilterU_RefreshStatus
 do
-	local UnitClass = UnitClass
-	local UnitExists = UnitExists
-	local UnitIsFriend = UnitIsFriend
-	local UnitGroupRolesAssigned = Grid2.UnitGroupRolesAssigned
-	local roster_types = Grid2.roster_types
+	local statuses = {}
+	
 	local filter_mt = {	__index = function(t,u)
 		if UnitExists(u) then
 			local load, r = t.source
@@ -164,58 +174,79 @@ do
 	end }
 
 	local function ClearUnitFilters(_, unit)
-		for status in next, statuses.unitFilter do
+		for status in next, statuses do
 			status.filtered[unit] = nil
 		end
-	end	
-	
-	function status:MakeUnitFilter() -- should be called from status:UpdateDB()
-		local load = self.dbx.load
-		if load and (load.unitType or load.unitReaction or load.unitClass or load.unitRole) then
-			if self.filtered then
-				wipe(self.filtered).source = load
-			else
-				self.filtered = setmetatable({source = load}, filter_mt)
-			end
-		else
-			self.filtered = nil
-		end
-	end
-	
-	function status:EnableUnitFilter() -- should be called from status:OnEnable()
-		local filtered = self.filtered
-		if filtered then
-			local list = statuses.unitFilter
-			if not next(list) then
-				Grid2.RegisterMessage( list, "Grid_UnitUpdated", ClearUnitFilters )
-			end	
-			list[self] = filtered
-		end
-	end
-
-	function status:DisableUnitFilter() -- should be called from status:OnDisable()
-		local filtered = self.filtered
-		if filtered then
-			local list = statuses.unitFilter
-			list[self] = nil
-			if not next(list) then
-				Grid2.UnregisterMessage( list, "Grid_UnitUpdated" )
-			end	
-		end	
-	end
-	
-	function status:Refresh(full)
-		if full then self:UpdateDB() end
-		if self.filtered then wipe(self.filtered).source = self.dbx.load end
-		if full then self:UpdateAllUnits() end
 	end	
 	
 	function Grid2:RefreshStatusesFilter(filterName) -- Called from GridCore.lua PLAYER_ROLES_ASSIGNED event
 		for status, filtered in next, statuses.unitFilter do
 			local load = filtered.source
-			wipe(filtered).source = load
-			status:UpdateAllUnits()
+			if load[filterName] then
+				wipe(filtered).source = load
+				status:UpdateAllUnits()
+			end	
+		end
+	end
+
+	-- public
+	function FilterU_RegisterStatus(self, load)
+		if load.unitType or load.unitReaction or load.unitClass or load.unitRole then
+			if self.filtered then
+				wipe(self.filtered).source = load
+			else
+				self.filtered = setmetatable({source = load}, filter_mt)
+			end
+			if not next(statuses) then
+				Grid2.RegisterMessage( statuses, "Grid_UnitUpdated", ClearUnitFilters )
+			end	
+			statuses[self] = self.filtered
+		else
+			self.filtered = nil
 		end
 	end
 	
+	function FilterU_UnregisterStatus(self)
+		if self.filtered then
+			statuses[self] = nil
+			if not next(statuses) then
+				Grid2.UnregisterMessage( statuses, "Grid_UnitUpdated" )
+			end
+			self.filtered = nil
+		end
+	end
+
+	function FilterU_RefreshStatus(self, load)
+		FilterU_RegisterStatus(self, load)
+		self:UpdateAllUnits()
+	end
+	
+end
+
+-----------------------------------------------------------------------
+-- status methods
+-----------------------------------------------------------------------
+
+local status = Grid2.statusPrototype
+
+function status:RegisterLoad() -- this is called from status:RegisterIndicator()
+	local load = self.dbx and self.dbx.load
+	if load then
+		FilterG_RegisterStatus(self, load)
+		FilterU_RegisterStatus(self, load)
+	end
+end
+
+function status:UnregisterLoad() -- this is called from status:UnregisterIndicator()
+	local load = self.dbx and self.dbx.load
+	if load then
+		FilterG_UnregisterStatus(self)
+		FilterU_UnregisterStatus(self)
+	end
+end
+
+function status:RefreshLoad() -- used by options
+	local load = self.dbx and self.dbx.load
+	FilterG_RefreshStatus(self, load)
+	FilterU_RefreshStatus(self, load)
 end

--- a/Options/GridUtils.lua
+++ b/Options/GridUtils.lua
@@ -441,6 +441,12 @@ function Grid2Options:RefreshStatus(status)
 	status:RefreshLoad()
 end
 
+-- Grid2Options:LayoutFrames()
+function Grid2Options:LayoutFrames()
+	Grid2Frame:LayoutFrames(true)
+	Grid2Frame:UpdateIndicators()
+end
+
 -- Reload indicator database configuration and refresh the indicator frames.
 -- indicator:UpdateDB() is always called to reload indicator database config
 -- method = "Create" | "Update" | key | nil

--- a/Options/GridUtils.lua
+++ b/Options/GridUtils.lua
@@ -436,6 +436,11 @@ function Grid2Options:UpdateIndicatorDB(indicator)
 	end
 end
 
+-- Grid2Options:RefreshStatus()
+function Grid2Options:RefreshStatus(status)
+	status:RefreshLoad()
+end
+
 -- Reload indicator database configuration and refresh the indicator frames.
 -- indicator:UpdateDB() is always called to reload indicator database config
 -- method = "Create" | "Update" | key | nil

--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -34,7 +34,7 @@ do
 			local priority = GetIndicatorNewPriority(indicator)
 			Grid2:DbSetMap(indicator.name, status.name, priority)
 			indicator:RegisterStatus(status, priority)
-			status:Refresh() -- TODO remove
+			Grid2Options:RefreshStatus(status)
 		else
 			Grid2:DbSetMap(indicator.name, status.name, nil)
 			indicator:UnregisterStatus(status)

--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -34,7 +34,7 @@ do
 			local priority = GetIndicatorNewPriority(indicator)
 			Grid2:DbSetMap(indicator.name, status.name, priority)
 			indicator:RegisterStatus(status, priority)
-			status:Refresh()
+			status:Refresh() -- TODO remove
 		else
 			Grid2:DbSetMap(indicator.name, status.name, nil)
 			indicator:UnregisterStatus(status)

--- a/Options/modules/indicators/IndicatorBorder.lua
+++ b/Options/modules/indicators/IndicatorBorder.lua
@@ -33,7 +33,7 @@ function Grid2Options:MakeIndicatorBorderCustomOptions(indicator,options)
 		get = function () return Grid2Frame.db.profile.frameBorder end,
 		set = function (_, frameBorder)
 			Grid2Frame.db.profile.frameBorder = frameBorder
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		end,
 		disabled = InCombatLockdown,
 	}
@@ -45,7 +45,7 @@ function Grid2Options:MakeIndicatorBorderCustomOptions(indicator,options)
 		get = function (info) return Grid2Frame.db.profile.frameBorderTexture or "Grid2 Flat" end,
 		set = function (info, v)
 			Grid2Frame.db.profile.frameBorderTexture = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()			
 		end,
 		values = AceGUIWidgetLSMlists.border,
 	}
@@ -57,7 +57,7 @@ function Grid2Options:MakeIndicatorBorderCustomOptions(indicator,options)
 		get = function() return self:UnpackColor( Grid2Frame.db.profile.frameColor ) end,
 		set = function( info, r,g,b,a )
 			self:PackColor( r,g,b,a, Grid2Frame.db.profile, "frameColor" )
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		 end,
 		hasAlpha = true,
 	}
@@ -75,7 +75,7 @@ function Grid2Options:MakeIndicatorBorderCustomOptions(indicator,options)
 		end,
 		set = function (_, v)
 			Grid2Frame.db.profile.frameBorderDistance = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()			
 		end,
 	}
 	options.message = {

--- a/Options/modules/statuses/Status.lua
+++ b/Options/modules/statuses/Status.lua
@@ -74,7 +74,7 @@ do
 					dbx.load[key] = nil
 					if not next(dbx.load) then dbx.load = nil end
 				end
-				self:RefreshStatus(status)				
+				RefreshStatus(status)				
 			end,
 			disabled = function() return dbx.load and dbx.load.disabled end,
 		}
@@ -90,7 +90,7 @@ do
 			end,
 			set = function(_,v)
 				dbx.load[key] = (v==2)
-				self:RefreshStatus(status)				
+				RefreshStatus(status)				
 			end,
 			disabled = function() return not dbx.load or dbx.load.disabled or dbx.load[key]==nil end,
 			values = values,

--- a/Options/modules/statuses/Status.lua
+++ b/Options/modules/statuses/Status.lua
@@ -53,11 +53,8 @@ do
 	end
 
 	local function RefreshStatus(status, isUnitFilter)
-		if isUnitFilter then
-			status:Refresh(true)
-		elseif status:RefreshLoad() then
-			Grid2Options:NotifyChange()
-		end
+		Grid2Options:RefreshStatus(status)
+		--Grid2Options:NotifyChange()
 	end
 
 	local function SetFilterBooleanOptions( status, options, order, key, defValue, name, desc, values )
@@ -77,7 +74,7 @@ do
 					dbx.load[key] = nil
 					if not next(dbx.load) then dbx.load = nil end
 				end
-				status:Refresh(true)
+				self:RefreshStatus(status)				
 			end,
 			disabled = function() return dbx.load and dbx.load.disabled end,
 		}
@@ -93,7 +90,7 @@ do
 			end,
 			set = function(_,v)
 				dbx.load[key] = (v==2)
-				status:Refresh(true)
+				self:RefreshStatus(status)				
 			end,
 			disabled = function() return not dbx.load or dbx.load.disabled or dbx.load[key]==nil end,
 			values = values,

--- a/Options/modules/statuses/StatusAura.lua
+++ b/Options/modules/statuses/StatusAura.lua
@@ -50,7 +50,7 @@ function Grid2Options:MakeStatusAuraEnableStacksOptions(status, options, optionP
 			end,
 			set = function (_, v)
 				status.dbx.enableStacks = v~=1 and v or nil
-				status:Refresh(true)
+				self:RefreshStatus(status)
 			end,
 		}
 	end
@@ -71,7 +71,7 @@ function Grid2Options:MakeStatusAuraMissingOptions(status, options, optionParams
 				status.dbx.valueIndex = nil
 				status.dbx.enableStacks = nil
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 			self:MakeStatusOptions(status)
 		end,
 	}
@@ -93,7 +93,7 @@ do
 				end,
 				set = function(_,v)
 					status.dbx.blinkThreshold = (v==3 and 1) or (v==2 and 0) or nil
-					status:Refresh(true)
+					self:RefreshStatus(status)
 					self:MakeStatusOptions(status)
 				end,
 				values = VALUES,
@@ -112,7 +112,7 @@ do
 				end,
 				set = function (_, v)
 					status.dbx.blinkThreshold = v
-					status:Refresh(true)
+					self:RefreshStatus(status)					
 				end,
 				hidden = function() return (status.dbx.blinkThreshold or 0)<=0 end,
 			}

--- a/Options/modules/statuses/StatusAuraBuffs.lua
+++ b/Options/modules/statuses/StatusAuraBuffs.lua
@@ -24,7 +24,7 @@ function Grid2Options:MakeStatusBuffsListOptions(status, options, optionParams)
 					table.insert(status.dbx.auras, tonumber(aura) or aura )
 				end
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.auras==nil end
 	}

--- a/Options/modules/statuses/StatusAuraDebuffs.lua
+++ b/Options/modules/statuses/StatusAuraDebuffs.lua
@@ -23,7 +23,7 @@ function Grid2Options:MakeStatusDebuffsListOptions(status, options, optionParams
 					table.insert(status.dbx.auras, tonumber(aura) or aura )
 				end
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.auras==nil end
 	}
@@ -41,7 +41,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function() return not status.dbx.lazyFiltering end,
 		set = function(_,v)
 			status.dbx.lazyFiltering = (not v) or nil
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end,
 	}
@@ -61,7 +61,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.aurasBak = status.dbx.auras
 				status.dbx.auras = nil
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)						
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -77,7 +77,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.aurasBak = status.dbx.auras
 				status.dbx.auras = nil
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -90,7 +90,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterTyped~=true end,
 		set = function (_, v)
 			status.dbx.filterTyped = (not v) or nil
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -106,7 +106,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterTyped = false
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -123,7 +123,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterBossDebuffs = false
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -135,7 +135,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterBossDebuffs~=true end,
 		set = function (_, v)
 			status.dbx.filterBossDebuffs = (not v) or nil
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -152,7 +152,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterLongDebuffs = false
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -164,7 +164,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterLongDebuffs~=true end,
 		set = function (_, v)
 			status.dbx.filterLongDebuffs = (not v) and true or nil
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -181,7 +181,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterCaster = false
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -193,7 +193,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterCaster~=true end,
 		set = function (_, v)
 			status.dbx.filterCaster = (not v) and true or nil
-			status:Refresh(true)
+			self:RefreshStatus(status)
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -219,7 +219,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.auras = nil
 				status.dbx.useWhiteList = nil
 			end
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 			self:MakeStatusOptions(status)
 		end,
 	}
@@ -238,7 +238,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.auras = nil
 			end
 			status.dbx.useWhiteList = nil
-			status:Refresh(true)
+			self:RefreshStatus(status)			
 			self:MakeStatusOptions(status)
 		end,
 	}

--- a/Options/modules/statuses/StatusMana.lua
+++ b/Options/modules/statuses/StatusMana.lua
@@ -30,7 +30,7 @@ local function ManaOptions(self, status, options, optionParams)
 		order = 120,
 		width = 'full',
 		name = L['Secondary Resource'],
-		desc = L["Mana visible when it is not the primary resource, for example: display mana for druids in bear form."],
+		desc = L["Mana visible when it is not the primary resource, for example: druids in bear form or shadow priests."],
 		get = function () return (status.dbx.displayType or 0)~=0 end,
 		set = function (info, v)
 			if v then

--- a/Options/modules/statuses/StatusMana.lua
+++ b/Options/modules/statuses/StatusMana.lua
@@ -5,34 +5,57 @@ for class in pairs(CLASSES_MANA) do
 	CLASSES_MANA[class] = LOCALIZED_CLASS_NAMES_MALE[class]
 end
 
-Grid2Options:RegisterStatusOptions("lowmana",  "mana", Grid2Options.MakeStatusColorThresholdOptions, {
-	titleIcon = "Interface\\Icons\\Inv_potion_86"
-})
-Grid2Options:RegisterStatusOptions("mana","mana",  function(self, status, options, optionParams)
-	self:MakeStatusStandardOptions(status, options, optionParams)
-end, {
-	titleIcon = "Interface\\Icons\\Inv_potion_72",
-	unitFilter = true,
-})
-
-Grid2Options:RegisterStatusOptions("manaalt", "mana",  function(self, status, options, optionParams)
+local function ManaOptions(self, status, options, optionParams)
 	self:MakeStatusStandardOptions(status, options, optionParams)
 	self:MakeHeaderOptions(options, "Display")	
-	options.display = {
+	options.display1 = {
 		type = "toggle",
 		order = 110,
 		width = 'full',
-		name = L['Display mana only when is not the default power type'],
-		get = function () return not status.dbx.showDefault end,
-		set = function ()
-			status.dbx.showDefault = not status.dbx.showDefault or nil
+		name = L['Primary Resource'],
+		desc = L["Mana visible when it is the primary resource."],
+		get = function () return (status.dbx.displayType or 0)~=2 end,
+		set = function (info, v)
+			if v then
+				status.dbx.displayType = 1
+			else
+				status.dbx.displayType = 2
+			end			
 			status:UpdateDB()
 			status:UpdateAllUnits()
 		end,
 	}	
-end, {
+	options.display2 = {
+		type = "toggle",
+		order = 120,
+		width = 'full',
+		name = L['Secondary Resource'],
+		desc = L["Mana visible when it is not the primary resource, for example: display mana for druids in bear form."],
+		get = function () return (status.dbx.displayType or 0)~=0 end,
+		set = function (info, v)
+			if v then
+				status.dbx.displayType = 1
+			else
+				status.dbx.displayType = false
+			end
+			status:UpdateDB()
+			status:UpdateAllUnits()
+		end,
+	}	
+end
+
+Grid2Options:RegisterStatusOptions("mana","mana",  ManaOptions, {
 	titleIcon = "Interface\\Icons\\Inv_potion_72",
 	unitFilter = true,
+})
+
+Grid2Options:RegisterStatusOptions("manaalt", "mana",  ManaOptions, {
+	titleIcon = "Interface\\Icons\\Inv_potion_72",
+	unitFilter = true,
+})
+
+Grid2Options:RegisterStatusOptions("lowmana",  "mana", Grid2Options.MakeStatusColorThresholdOptions, {
+	titleIcon = "Interface\\Icons\\Inv_potion_86"
 })
 
 Grid2Options:RegisterStatusOptions("poweralt", "mana", Grid2Options.MakeStatusColorOptions, {

--- a/Options/modules/themes/GridGeneral.lua
+++ b/Options/modules/themes/GridGeneral.lua
@@ -614,7 +614,7 @@ local frameOptions2 = { headerback = {
 		get = function (info) return theme.frame.frameTexture or "Gradient" end,
 		set = function (info, v)
 			theme.frame.frameTexture = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		end,
 		values = AceGUIWidgetLSMlists.statusbar,
 },  backgroundColor = {
@@ -663,7 +663,7 @@ local frameOptions2 = { headerback = {
 	get = function () return theme.frame.frameBorder end,
 	set = function (_, frameBorder)
 		theme.frame.frameBorder = frameBorder
-		Grid2Frame:LayoutFrames(true)
+		Grid2Options:LayoutFrames()
 	end,
 	disabled = InCombatLockdown,
 }, innerBordercolor = {
@@ -678,7 +678,7 @@ local frameOptions2 = { headerback = {
 		set = function( info, r,g,b,a )
 			local c= theme.frame.frameColor
 			c.r, c.g, c.b, c.a = r, g, b, a
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()			
 		 end,
 		hasAlpha = true,
 }, innerBorderDistance= {
@@ -694,7 +694,7 @@ local frameOptions2 = { headerback = {
 		end,
 		set = function (_, v)
 			theme.frame.frameBorderDistance = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		end,
 }, borderIndicatorTexture = {
 	type = "select", dialogControl = "LSM30_Border",
@@ -704,7 +704,7 @@ local frameOptions2 = { headerback = {
 	get = function (info) return theme.frame.frameBorderTexture or "Grid2 Flat" end,
 	set = function (info, v)
 		theme.frame.frameBorderTexture = v
-		Grid2Frame:LayoutFrames(true)
+		Grid2Options:LayoutFrames()		
 	end,
 	values = AceGUIWidgetLSMlists.border,
 
@@ -722,7 +722,7 @@ local frameOptions2 = { headerback = {
 		end,
 		set = function (_, v)
 			theme.frame.mouseoverHighlight = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		end,
 }, mouseoverColor = {
 		type = "color",
@@ -736,7 +736,7 @@ local frameOptions2 = { headerback = {
 		set = function( info, r,g,b,a )
 			local c = theme.frame.mouseoverColor
 			c.r, c.g, c.b, c.a = r, g, b, a
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()			
 		 end,
 		hasAlpha = true,
 		hidden = function() return not theme.frame.mouseoverHighlight end,
@@ -748,7 +748,7 @@ local frameOptions2 = { headerback = {
 		get = function (info) return theme.frame.mouseoverTexture or "Blizzard Quest Title Highlight" end,
 		set = function (info, v)
 			theme.frame.mouseoverTexture = v
-			Grid2Frame:LayoutFrames(true)
+			Grid2Options:LayoutFrames()
 		end,
 		values = AceGUIWidgetLSMlists.background,
 		hidden = function() return not theme.frame.mouseoverHighlight end,

--- a/modules/IndicatorBar.lua
+++ b/modules/IndicatorBar.lua
@@ -204,6 +204,12 @@ local function Bar_Disable(self, parent)
 	bar:Hide()
 	bar:SetParent(nil)
 	bar:ClearAllPoints()
+	tdestroy(bar)	
+end
+
+local function Bar_Destroy(self, parent, bar)
+	tdestroy(bar)
+	bar.indicator = nil
 end
 
 local function Bar_UpdateDB(self)
@@ -283,6 +289,7 @@ local function Create(indicatorKey, dbx)
 	local Bar = Grid2.indicatorPrototype:new(indicatorKey)
 	Bar.dbx            = dbx
 	Bar.Create         = Bar_CreateHH
+	Bar.Destroy        = Bar_Destroy
 	Bar.OnUpdate       = Bar_OnUpdate
 	Bar.SetOrientation = Bar_SetOrientation
 	Bar.Disable        = Bar_Disable

--- a/modules/IndicatorText.lua
+++ b/modules/IndicatorText.lua
@@ -236,8 +236,10 @@ end
 
 local function Text_Disable(self, parent)
 	local f = parent[self.name]
+	local Text = f.Text
+	Text:Hide()
+	if timers[Text] then TimerStop(Tsext) end
 	f:Hide()
-	f.Text:Hide()
 	f:SetParent(nil)
 	f:ClearAllPoints()
 end

--- a/modules/IndicatorText.lua
+++ b/modules/IndicatorText.lua
@@ -242,6 +242,11 @@ local function Text_Disable(self, parent)
 	f:ClearAllPoints()
 end
 
+local function Text_Destroy(self, parent, frame)
+	local Text = frame.Text
+	if timers[Text] then TimerStop(Text) end
+end
+
 local function Text_UpdateDB(self)
 	-- text fmt
 	local fmt = Grid2.db.profile.formatting
@@ -307,6 +312,7 @@ local function Create(indicatorKey, dbx)
 	local indicator = Grid2.indicatorPrototype:new(indicatorKey)
 	indicator.dbx = dbx
 	indicator.Create = Text_Create
+	indicator.Destroy = Text_Destroy
 	indicator.Layout = Text_Layout
 	indicator.Disable = Text_Disable
 	indicator.UpdateDB = Text_UpdateDB

--- a/modules/StatusAuras.lua
+++ b/modules/StatusAuras.lua
@@ -149,7 +149,6 @@ do
 				UnitAura = LibStub("LibClassicDurations").UnitAuraDirect
 			end
 		end
-		status:EnableUnitFilter()
 	end
 	DisableAuraEvents = function(status)
 		if not next(Statuses) then
@@ -159,7 +158,6 @@ do
 				LibStub("LibClassicDurations"):Unregister(Grid2)
 			end
 		end
-		status:DisableUnitFilter()
 	end
 end
 
@@ -318,18 +316,9 @@ do
 	local fmt = string.format
 	local UnitHealthMax = UnitHealthMax
 	local unit_is_pet   = Grid2.owner_of_unit
-	local function Refresh(self, full)
-		if full then
-			self:UpdateDB()
-		end
-		if self.filtered then
-			wipe(self.filtered).source = self.dbx.load
-		end
+	local function OnWakeUp(self)
 		for unit in Grid2:IterateRosterUnits() do
 			AuraFrame_OnEvent(nil,nil,unit)
-		end
-		if full then
-			self:UpdateAllUnits()
 		end
 	end
 	local function Reset(self, unit)
@@ -500,7 +489,6 @@ do
 		if self.enabled then self:OnDisable() end
 		local dbx = dbx or self.dbx
 		local blinkThreshold = dbx.blinkThreshold or nil
-		self:MakeUnitFilter()
 		self.vId = dbx.valueIndex or 0
 		self.valMax = dbx.valueMax
 		self.GetPercent = dbx.valueIndex and (dbx.valueMax and GetPercentMax or GetPercentHealth) or Grid2.statusLibrary.GetPercent
@@ -612,14 +600,13 @@ do
 		status.typ = {}
 		status.val = {}
 		status.tkr = {}
-		status.Refresh     = Refresh
 		status.Reset       = Reset
 		status.GetCountMax = GetCountMax
 		status.UpdateDB    = UpdateDB
 		status.OnEnable    = OnEnable
 		status.OnDisable   = OnDisable
+		status.OnWakeUp    = OnWakeUp
 		Grid2:RegisterStatus(status, statusTypes, baseKey, dbx)
-		status:UpdateDB()
 		return status
 	end
 end

--- a/modules/StatusBanzai.lua
+++ b/modules/StatusBanzai.lua
@@ -121,9 +121,6 @@ local function status_OnEnable(self)
 			RegisterEvent("PLAYER_REGEN_DISABLED", CombatEnterEvent)
 		end
 	end
-	if self.UpdateDB then
-		self:UpdateDB()
-	end
 	statuses[self] = true
 end
 

--- a/modules/StatusCombat.lua
+++ b/modules/StatusCombat.lua
@@ -49,7 +49,6 @@ local function UpdateUnits()
 end
 
 function Combat:OnEnable()
-	self:UpdateDB()
 	self:RegisterMessage("Grid_UnitUpdated")
 	self:RegisterMessage("Grid_UnitLeft")
 	timer:Play()
@@ -113,7 +112,6 @@ function MyCombat:_IsNotActive()
 end
 
 function MyCombat:OnEnable()
-	self:UpdateDB()
 	self:RegisterEvent("PLAYER_REGEN_ENABLED",  "CombatChanged" )
 	self:RegisterEvent("PLAYER_REGEN_DISABLED", "CombatChanged" )
 	inCombat = InCombatLockdown()

--- a/modules/StatusDirection.lua
+++ b/modules/StatusDirection.lua
@@ -182,7 +182,6 @@ function Direction:UpdateDB()
 end
 
 function Direction:OnEnable()
-	self:UpdateDB()
 	self:SetTimer(true)
 	if guessDirections then
 		playerx = UIParent:GetWidth()  * UIParent:GetEffectiveScale() / 2

--- a/modules/StatusHealAbsorbs.lua
+++ b/modules/StatusHealAbsorbs.lua
@@ -10,7 +10,6 @@ local UnitGetTotalHealAbsorbs = UnitGetTotalHealAbsorbs
 local UnitHealthMax = UnitHealthMax
 
 function Shields:OnEnable()
-	self:UpdateDB()
 	self:RegisterEvent("UNIT_HEAL_ABSORB_AMOUNT_CHANGED")
 end
 

--- a/modules/StatusHealsAoe.lua
+++ b/modules/StatusHealsAoe.lua
@@ -143,7 +143,6 @@ Grid2.setupFunc["aoe-heals"] = function(baseKey, dbx)
 	status.GetText = GetText
 	status.UpdateDB = UpdateDB
 	Grid2:RegisterStatus(status, {"color", "icon", "text"}, baseKey, dbx)
-	status:UpdateDB()	
 	return status
 end
 

--- a/modules/StatusHealth.lua
+++ b/modules/StatusHealth.lua
@@ -298,7 +298,6 @@ end
 
 local function CreateHealthCurrent(baseKey, dbx)
 	Grid2:RegisterStatus(HealthCurrent, {"percent", "text", "color"}, baseKey, dbx)
-	HealthCurrent:UpdateDB()
 	return HealthCurrent
 end
 
@@ -325,7 +324,6 @@ end
 
 local function CreateHealthLow(baseKey, dbx)
 	Grid2:RegisterStatus(HealthLow, {"percent", "color"}, baseKey, dbx)
-	HealthLow:UpdateDB()
 	return HealthLow
 end
 
@@ -383,7 +381,6 @@ Grid2:DbSetStatusDefaultValue( "feign-death", {type = "feign-death", color1 = {r
 HealthDeficit.GetColor  = Grid2.statusLibrary.GetColor
 
 function HealthDeficit:OnEnable()
-	self:UpdateDB()
 	Health_Enable(self)
 	healthdeficit_enabled = self.dbx.addIncomingHeals~=nil
 	if healthdeficit_enabled and not Heals.enabled then
@@ -745,7 +742,6 @@ function Heals:UpdateDB()
 end
 
 function Heals:OnEnable()
-	self:UpdateDB()
 	RegisterHealEvents(1) -- set bit1
 	if self.dbx.includeHealAbsorbs and not Grid2.isClassic then
 		RegisterEvent("UNIT_HEAL_ABSORB_AMOUNT_CHANGED", HealsUpdateEvent)
@@ -810,7 +806,6 @@ function OverHeals:UpdateDB()
 end
 
 function OverHeals:OnEnable()
-	self:UpdateDB()
 	Health_Enable(self)
 	RegisterHealEvents(4) -- set bit3
 	overheals_enabled = true
@@ -869,7 +864,6 @@ function MyHeals:UpdateDB()
 end
 
 function MyHeals:OnEnable()
-	self:UpdateDB()
 	RegisterHealEvents(2) -- set bit2
 	myheal_required = bit.bor(myheal_required,2) -- set bit2
 	myheals_enabled = true

--- a/modules/StatusMana.lua
+++ b/modules/StatusMana.lua
@@ -121,14 +121,12 @@ local powerColors = {}
 Power.OnEnable  = status_OnEnable
 Power.OnDisable = status_OnDisable
 
-function Power:UpdateUnitPowerStandard(unit, powerType)
-   if powerColors[powerType] then
-		self:UpdateIndicators(unit)
-	end
+function Power:UpdateUnitPowerStandard(unit, powerType, event)
+	self:UpdateIndicators(unit)
 end
 
 function Power:UpdateUnitPowerFilter(unit, powerType)
-   if powerColors[powerType] and not self.filtered[unit] then
+	if not self.filtered[unit] then
 		self:UpdateIndicators(unit)
 	end
 end
@@ -198,14 +196,14 @@ Grid2:DbSetStatusDefaultValue( "power", {type = "power", colorCount = 10,
 })
 
 -- Mana, Manaalt statuses
-local function Mana_UpdateUnitPower(self, unit, powerType, event)
-	if powerType=='MANA' or event=='UNIT_DISPLAYPOWER' then
+local function Mana_UpdateUnitPower(self, unit, powerType)
+	if powerType=='MANA' or powerType==nil then -- powerType==nil => UNIT_DISPLAYPOWER event
 		self:UpdateIndicators(unit)
 	end	
 end
 
-local function Mana_UpdateUnitPowerF(self, unit, powerType, event)
-	if not self.filtered[unit] and (powerType=='MANA' or event=='UNIT_DISPLAYPOWER') then
+local function Mana_UpdateUnitPowerF(self, unit, powerType)
+	if not self.filtered[unit] and (powerType=='MANA' or powerType==nil) then
 		self:UpdateIndicators(unit)
 	end	
 end

--- a/modules/StatusMana.lua
+++ b/modules/StatusMana.lua
@@ -15,7 +15,6 @@ local UnitManaMax = UnitPowerMax
 local UnitPowerType = UnitPowerType
 local UnitPower = UnitPower
 local UnitPowerMax = UnitPowerMax
-local UnitIsPlayer = UnitIsPlayer
 local UnitClass = UnitClass
 
 local statuses = {}  -- Enabled statuses
@@ -151,17 +150,17 @@ Power.OnEnable  = status_OnEnable
 Power.OnDisable = status_OnDisable
 
 function Power:UpdateUnitPower(unit, powerType)
-   if UnitIsPlayer(unit) and powerColors[ powerType ] then
+   if powerColors[powerType] then
 		self:UpdateIndicators(unit)
 	end
 end
 
 function Power:IsActiveStandard(unit)
-  return UnitIsPlayer(unit)
+  return true
 end
 
 function Power:IsActiveFilter(unit)
-  return not self.filtered[unit] and UnitIsPlayer(unit)
+  return not self.filtered[unit]
 end
 
 function Power:GetPercent(unit)
@@ -179,22 +178,25 @@ function Power:GetText(unit)
 end
 
 function Power:GetColor(unit)
-	local _,type= UnitPowerType(unit)
-	local c= powerColors[type] or powerColors["MANA"]
+	local _, type = UnitPowerType(unit)
+	local c = powerColors[type] or powerColors.MANA
 	return c.r, c.g, c.b, c.a
 end
 
 function Power:UpdateDB()
-	powerColors["MANA"] = self.dbx.color1
-	powerColors["RAGE"] = self.dbx.color2
-	powerColors["FOCUS"] = self.dbx.color3
-	powerColors["ENERGY"] = self.dbx.color4
-	powerColors["RUNIC_POWER"] = self.dbx.color5
-	powerColors["INSANITY"] = self.dbx.color6
-	powerColors["MAELSTROM"] = self.dbx.color7
-	powerColors["LUNAR_POWER"] = self.dbx.color8
-	powerColors["FURY"] = self.dbx.color9
-	powerColors["PAIN"] = self.dbx.color10
+	local dbx = self.dbx
+	powerColors["MANA"] = dbx.color1
+	powerColors["RAGE"] = dbx.color2
+	powerColors["FOCUS"] = dbx.color3
+	powerColors["ENERGY"] = dbx.color4
+	powerColors["RUNIC_POWER"] = dbx.color5
+	powerColors["INSANITY"] = dbx.color6
+	powerColors["MAELSTROM"] = dbx.color7
+	powerColors["LUNAR_POWER"] = dbx.color8
+	powerColors["FURY"] = dbx.color9
+	powerColors["PAIN"] = dbx.color10
+	powerColors["POWER_TYPE_FOCUS"] = self.dbx.color3 	  -- Codes returned by UnitPowerType() in 
+	powerColors["POWER_TYPE_RED_POWER"] = self.dbx.color2 -- garrison proving grounds for friendly NPCs
 	self.IsActive = self.filtered and self.IsActiveFilter or self.IsActiveStandard
 end
 

--- a/modules/StatusMana.lua
+++ b/modules/StatusMana.lua
@@ -52,35 +52,19 @@ end
 
 -- Mana status
 Mana.GetColor = Grid2.statusLibrary.GetColor
-
-function Mana:OnEnable()
-	self:EnableUnitFilter()
-	status_OnEnable(self)
-	if self.dbx.showOnlyHealers then
-		self:RegisterEvent("PLAYER_ROLES_ASSIGNED", "UpdateAllUnits")
-		self.rolesEvent = true
-	end
-end
-
-function Mana:OnDisable()
-	self:DisableUnitFilter()
-	status_OnDisable(self)
-	if self.rolesEvent then
-		self:UnregisterEvent("PLAYER_ROLES_ASSIGNED")
-		self.rolesEvent = nil
-	end
-end
+Mana.OnEnable  = status_OnEnable
+Mana.OnDisable = status_OnDisable
 
 function Mana:UpdateUnitPower(unit, powerType)
 	self:UpdateIndicators(unit)
 end
 
 function Mana:IsActiveStandard(unit)
-	return UnitPowerType(unit) == 0
+	return UnitPowerType(unit)==0
 end
 
 function Mana:IsActiveFilter(unit)
-	return (unit=="player" or not self.filtered[unit]) and UnitPowerType(unit)==0
+	return not self.filtered[unit] and UnitPowerType(unit)==0
 end
 
 function Mana:GetPercent(unit)
@@ -93,13 +77,11 @@ function Mana:GetText(unit)
 end
 
 function Mana:UpdateDB()
-	self:MakeUnitFilter()
 	self.IsActive = self.filtered and self.IsActiveFilter or self.IsActiveStandard
 end
 
 Grid2.setupFunc["mana"] = function(baseKey, dbx)
 	Grid2:RegisterStatus(Mana, {"percent", "text", "color"}, baseKey, dbx)
-	Mana:UpdateDB()
 	return Mana
 end
 
@@ -117,7 +99,7 @@ function LowMana:UpdateUnitPower(unit, powerType)
 end
 
 function LowMana:IsActive(unit)
-	return (UnitPowerType(unit) == 0) and (Mana:GetPercent(unit) < self.dbx.threshold)
+	return UnitPowerType(unit)==0 and Mana:GetPercent(unit)<self.dbx.threshold
 end
 
 Grid2.setupFunc["lowmana"] = function(baseKey, dbx)
@@ -165,15 +147,8 @@ Grid2:DbSetStatusDefaultValue( "poweralt", {type = "poweralt", color1= {r=1,g=0,
 -- Power status
 local powerColors= {}
 
-function Power:OnEnable()
-	self:EnableUnitFilter()
-	status_OnEnable(self)
-end
-
-function Power:OnDisable()
-	self:DisableUnitFilter()
-	status_OnDisable(self)
-end
+Power.OnEnable  = status_OnEnable
+Power.OnDisable = status_OnDisable
 
 function Power:UpdateUnitPower(unit, powerType)
    if UnitIsPlayer(unit) and powerColors[ powerType ] then
@@ -220,13 +195,11 @@ function Power:UpdateDB()
 	powerColors["LUNAR_POWER"] = self.dbx.color8
 	powerColors["FURY"] = self.dbx.color9
 	powerColors["PAIN"] = self.dbx.color10
-	self:MakeUnitFilter()
 	self.IsActive = self.filtered and self.IsActiveFilter or self.IsActiveStandard
 end
 
 Grid2.setupFunc["power"] = function(baseKey, dbx)
 	Grid2:RegisterStatus(Power, {"percent", "text", "color"}, baseKey, dbx)
-	Power:UpdateDB()
 	return Power
 end
 
@@ -246,16 +219,8 @@ Grid2:DbSetStatusDefaultValue( "power", {type = "power", colorCount = 10,
 
 -- Mana Alt status
 ManaAlt.GetColor = Grid2.statusLibrary.GetColor
-
-function ManaAlt:OnEnable()
-	self:EnableUnitFilter()
-	status_OnEnable(self)
-end
-
-function ManaAlt:OnDisable()
-	self:DisableUnitFilter()
-	status_OnDisable(self)
-end
+ManaAlt.OnEnable = status_OnEnable
+ManaAlt.OnDisable= status_OnDisable
 
 function ManaAlt:UpdateUnitPower(unit, powerType, event)
 	if not (self.filtered and self.filtered[unit]) and (event=='UNIT_DISPLAYPOWER' or powerType=='MANA') then
@@ -265,12 +230,12 @@ end
 
 function ManaAlt:IsActiveStandard(unit)
 	local filtered = self.filtered
-	return not (filtered and filtered[unit]) and UnitPowerType(unit) ~= 0
+	return not (filtered and filtered[unit]) and UnitPowerMax(unit,0)~=0 and UnitPowerType(unit)~=0
 end
 
 function ManaAlt:IsActiveAlways(unit)
 	local filtered = self.filtered
-	return not (filtered and filtered[unit])
+	return not (filtered and filtered[unit]) and UnitPowerMax(unit,0)~=0
 end
 
 function ManaAlt:GetPercent(unit)
@@ -283,14 +248,12 @@ function ManaAlt:GetText(unit)
 end
 
 function ManaAlt:UpdateDB()
-	self:MakeUnitFilter()
 	self.IsActive = self.dbx.showDefault and self.IsActiveAlways or self.IsActiveStandard	
 end
 
 Grid2.setupFunc["manaalt"] = function(baseKey, dbx)
 	Grid2:RegisterStatus(ManaAlt, {"percent", "text", "color"}, baseKey, dbx)
-	ManaAlt:UpdateDB()
 	return ManaAlt
 end
 
-Grid2:DbSetStatusDefaultValue( "manaalt", {type = "manaalt", classes = {PRIEST=true}, color1={r=0,g=0,b=1,a=1}} )
+Grid2:DbSetStatusDefaultValue( "manaalt", {type = "manaalt", color1={r=0,g=0,b=1,a=1}} )

--- a/modules/StatusName.lua
+++ b/modules/StatusName.lua
@@ -56,7 +56,6 @@ end
 
 local function Create(baseKey, dbx)
 	Grid2:RegisterStatus(Name, {"text","tooltip"}, baseKey, dbx)
-	Name:UpdateDB()
 	return Name
 end
 

--- a/modules/StatusRange.lua
+++ b/modules/StatusRange.lua
@@ -146,7 +146,6 @@ function Range:IsActive(unit)
 end
 
 function Range:OnEnable()
-	self:UpdateDB()
 	self:RegisterMessage("Grid_UnitUpdated")
 	self:RegisterMessage("Grid_UnitLeft")
 	self:RegisterMessage("Grid_PlayerSpecChanged")

--- a/modules/StatusRole.lua
+++ b/modules/StatusRole.lua
@@ -362,7 +362,6 @@ DungeonRole.SetHideInCombat = SetHideInCombat
 
 function DungeonRole:OnEnable()
 	self:SetHideInCombat(self.dbx.hideInCombat)
-	self:UpdateDB()
 	self:RegisterMessage("Grid_PlayerRolesAssigned", "UpdateAllUnits")
 end
 

--- a/modules/StatusShields.lua
+++ b/modules/StatusShields.lua
@@ -13,7 +13,6 @@ local UnitHealthMax = UnitHealthMax
 local Shields = Grid2.statusPrototype:new("shields")
 
 function Shields:OnEnable()
-	self:UpdateDB()
 	self:RegisterEvent("UNIT_ABSORB_AMOUNT_CHANGED")
 	self:RegisterEvent("UNIT_MAXHEALTH", "UNIT_ABSORB_AMOUNT_CHANGED")
 end

--- a/modules/StatusThreat.lua
+++ b/modules/StatusThreat.lua
@@ -16,7 +16,6 @@ function Threat:UpdateUnit(_, unit)
 end
 
 function Threat:OnEnable()
-	self:UpdateDB()
 	self:RegisterEvent("UNIT_THREAT_SITUATION_UPDATE", "UpdateUnit")
 	self:RegisterEvent("ZONE_CHANGED_NEW_AREA", "UpdateAllUnits")
 end

--- a/modules/StatusVehicle.lua
+++ b/modules/StatusVehicle.lua
@@ -68,7 +68,6 @@ end
 
 local function Create(baseKey, dbx)
 	Grid2:RegisterStatus(Vehicle, {"color", "icon", "percent", "text"}, baseKey, dbx)
-	Vehicle:UpdateDB()
 	return Vehicle
 end
 


### PR DESCRIPTION
Now status unit load conditions can be used in another non-aura statuses like mana and power.
Added new ManaAlt status to be able to create an extra bar to display secondary mana resources.