### PR TITLE
Add combine stacks option on Debuffs Group status

### DIFF
--- a/Options/modules/statuses/StatusAuraDebuffs.lua
+++ b/Options/modules/statuses/StatusAuraDebuffs.lua
@@ -61,7 +61,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.aurasBak = status.dbx.auras
 				status.dbx.auras = nil
 			end
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -77,7 +77,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.aurasBak = status.dbx.auras
 				status.dbx.auras = nil
 			end
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -123,7 +123,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterBossDebuffs = false
 			end
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -135,7 +135,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterBossDebuffs~=true end,
 		set = function (_, v)
 			status.dbx.filterBossDebuffs = (not v) or nil
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -152,7 +152,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterLongDebuffs = false
 			end
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -164,7 +164,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterLongDebuffs~=true end,
 		set = function (_, v)
 			status.dbx.filterLongDebuffs = (not v) and true or nil
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -181,7 +181,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 			else
 				status.dbx.filterCaster = false
 			end
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -193,7 +193,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		get = function () return status.dbx.filterCaster~=true end,
 		set = function (_, v)
 			status.dbx.filterCaster = (not v) and true or nil
-			status:Refresh()			
+			status:Refresh()
 		end,
 		hidden = function() return status.dbx.useWhiteList end
 	}
@@ -219,7 +219,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.auras = nil
 				status.dbx.useWhiteList = nil
 			end
-			status:Refresh()			
+			status:Refresh()
 			self:MakeStatusOptions(status)
 		end,
 	}
@@ -238,7 +238,7 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 				status.dbx.auras = nil
 			end
 			status.dbx.useWhiteList = nil
-			status:Refresh()			
+			status:Refresh()
 			self:MakeStatusOptions(status)
 		end,
 	}
@@ -251,6 +251,7 @@ function Grid2Options:MakeStatusDebuffsGeneralOptions(status, options, optionPar
 	self:MakeStatusAuraColorThresholdOptions(status, options, optionParams)
 	self:MakeStatusBlinkThresholdOptions(status, options, optionParams)
 	self:MakeStatusDebuffsFilterOptions(status, options, optionParams)
+	self:MakeStatusAuraCombineStacksOptions(status, options, optionParams)
 	return options
 end
 

--- a/modules/StatusAuras.lua
+++ b/modules/StatusAuras.lua
@@ -70,8 +70,18 @@ do
 				end
 			end
 			for s in next, DebuffGroups do
-				if (not s.seen) and s:UpdateState(u, nam, dur, cas, bos, typ, pTypes) then
-					s.seen, s.idx[u], s.tex[u], s.cnt[u], s.dur[u], s.exp[u], s.typ[u], s.tkr[u] = 1, i, tex, cnt, dur, exp, typ, 1
+				if s.combineStacks then -- combine stacks debuffs (for "icon" indicator)
+					if s:UpdateState(u, nam, dur, cas, bos, typ, pTypes) then
+						if s.seen then -- add extra debuffs stacks
+							s.cnt[u] = s.cnt[u] + cnt
+						else -- debuff must be always marked to be updated (seen=1) and cnt must be initialized even if first debuff is not new and didn't change
+							s.seen, s.idx[u], s.tex[u], s.cnt[u], s.dur[u], s.exp[u], s.typ[u], s.tkr[u] = 1, i, tex, cnt, dur, exp, typ, 1
+						end
+					end
+				else -- standard debuffs
+					if (not s.seen) and s:UpdateState(u, nam, dur, cas, bos, typ, pTypes) then
+						s.seen, s.idx[u], s.tex[u], s.cnt[u], s.dur[u], s.exp[u], s.typ[u], s.tkr[u] = 1, i, tex, cnt, dur, exp, typ, 1
+					end
 				end
 			end
 			i = i + 1


### PR DESCRIPTION
Add the "Combine Stacks" option for Debuffs Group status for icons and icon indicators. Just like the already existing option for Debuff status, this option enables multiple copies of the same debuff to be displayed as if they were multiple stacks of the same debuff.

**Note:** Moreover, wouldn't it be better to make it a general option instead of having it as an option in each status?