### PR TITLE
Improve the layout of Icons indicators 

### DIFF
--- a/Options/modules/indicators/IndicatorIcons.lua
+++ b/Options/modules/indicators/IndicatorIcons.lua
@@ -164,6 +164,18 @@ function Grid2Options:MakeIndicatorAuraIconsSizeOptions(indicator, options, opti
 			self:RefreshIndicator(indicator, "Layout")
 		end,
 	}
+	options.smartLayout = {
+		type = "toggle",
+		name = L["Use Smart Layout"],
+		desc = L["When Smart Layout is enabled, icons in incomplete rows will be aligned centrally"],
+		order = 19,
+		tristate = false,
+		get = function () return indicator.dbx.smartLayout end,
+		set = function (_, v)
+			indicator.dbx.smartLayout = v or nil
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+	}
 end
 
 function Grid2Options:MakeIndicatorAuraIconsLocationOptions(indicator, options)

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -265,7 +265,7 @@ local function Icon_UpdateDB(self)
 	self.maxIcons       = dbx.maxIcons or 3
 	self.maxIconsPerRow = dbx.maxIconsPerRow or 3
 	self.maxRows        = math.floor(self.maxIcons/self.maxIconsPerRow) + (self.maxIcons%self.maxIconsPerRow==0 and 0 or 1)
-	self.smartLayout 	= false
+	self.smartLayout 	= dbx.smartLayout or false
 	self.uy 			= 0
 	self.vx 			= 0
 	self.ux 			= pointsX[self.anchorIcon]


### PR DESCRIPTION
This PR supplies a number of fixes and improvements for the Icons indicator.  It has been a long-standing annoyance for me that if you have an Icons indicator in the center of a frame that the icons are laid out in a fixed manner, no matter how many icons are actually active.

### Removes unnecessary space so that the indicator correctly centers.  
This was caused by adding the icon spacing to the last row and last column.
Before ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/138ba282-139e-4b0d-8f83-840b5db600df) After ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/ba1b0f4e-7307-4465-b4b3-26d8cac7602b)

### Sets the width of the indicator to be the maximum possible width as set by Max Icons and not Icons Per Row
Example using Max Icons = 3 and Icons per Row = 5
Before  ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/345d58d7-9497-45e7-9a1e-e91bd9a002ae) After  ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/90ebb614-95e0-46f8-9734-00fe0e3dba51)

### New Feature - Smart Layout
When Smart Layout is enabled, Grid2 will grow icons from the middle of the indicator, ensuring a predictable layout when the Anchor is set to Center
![image](https://github.com/michaelnpsp/Grid2/assets/54023126/ee4afcd7-6bbb-43bf-81ae-97cb000c0101)

1. If the number of icons in a row is less than the maximum then offset the icons to align them in the middle of the indicator
Before ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/92580c62-3eb6-4d56-8d79-8c7068d92ad7) After ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/35fc9bcd-992d-42d6-bc25-5b870d9d5d40)

2. This also works with multiple rows
Before ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/670d1505-1e06-4b95-a21a-ff31ea57778b) After ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/5b2af836-d45c-49cc-8721-ff71e37d177b)![image](https://github.com/michaelnpsp/Grid2/assets/54023126/2b688166-f403-4927-b31a-f259e90e08f1)

3. Also works for Vertical orientation
![image](https://github.com/michaelnpsp/Grid2/assets/54023126/8084dce6-6010-4e91-ae02-a84379a6f3e4) ![image](https://github.com/michaelnpsp/Grid2/assets/54023126/7e84ceab-896a-418e-8b2f-36ee46651228)
