### PR TITLE
Update raid debuffs to be ready for Season 1

### DIFF
--- a/RaidDebuffsOptions/RaidDebuffsBfA.lua
+++ b/RaidDebuffsOptions/RaidDebuffsBfA.lua
@@ -21,14 +21,14 @@ RDDB["Battle for Azeroth"] = {
 		263234, -- Arcing Blade
 		268993, -- Golpe bajo
 		263778, -- Fuerza de vendaval
-		225080, -- Reencarnación
+		225080, -- Reencarnaciï¿½n
 		},
 		["Merektha"] = {
 		order = 2, ejid = 2143,
 		267027, -- Cytotoxin
 		263958, -- A Knot of Snakes
 		261732, -- Blinding Sand
-		263927, -- Charco tóxico
+		263927, -- Charco tï¿½xico
 		},
 		["Galvazzt"] = {
 		order = 3, ejid = 2144,
@@ -38,7 +38,7 @@ RDDB["Battle for Azeroth"] = {
 		["Avatar of Sethraliss"] = {
 		order = 4, ejid = 2145,
 		269686, -- Plague
-		269670, -- Potenciación
+		269670, -- Potenciaciï¿½n
 		268024, -- Pulso
 		},
 		["Trash"] = {
@@ -46,10 +46,10 @@ RDDB["Battle for Azeroth"] = {
 		273563, -- Neurotoxina
 		272657, -- Aliento nocivo
 		272655, -- Arena asoladora
-		272696, -- Relámpagos embotellados
+		272696, -- Relï¿½mpagos embotellados
 		272699, -- Flema venenosa
 		268013, -- Choque de llamas
-		268007, -- Ataque al corazón
+		268007, -- Ataque al corazï¿½n
 		268008, -- Amuleto de serpiente
 		},
 	},
@@ -68,7 +68,7 @@ RDDB["Battle for Azeroth"] = {
 		["Ring of Booty"] = {
 		order = 3, ejid = 2094,
 		256553, -- Flailing Shark
-		256363, -- Puñetazo desgarrador
+		256363, -- Puï¿½etazo desgarrador
 		},
 		["Harlan Sweete"] = {
 		order = 4, ejid = 2095,
@@ -96,7 +96,7 @@ RDDB["Battle for Azeroth"] = {
 		["Sporecaller Zancha"] = {
 		order = 3, ejid = 2130,
 		259714, -- Decaying Spores
-		259718, -- Agitación
+		259718, -- Agitaciï¿½n
 		273226, -- Esporas putrefactas
 		},
 		["Unbound Abomination"] = {
@@ -112,9 +112,9 @@ RDDB["Battle for Azeroth"] = {
 		266107, -- Sed de sangre
 		266265, -- Asalto malvado
 		272180, -- Descarga mortal
-		265468, -- Maldición fulminante
+		265468, -- Maldiciï¿½n fulminante
 		272609, -- Mirada enloquecedora
-		265511, -- Drenaje de espíritu
+		265511, -- Drenaje de espï¿½ritu
 		278961, -- Mente putrefacta
 		273599, -- Aliento podrido
 		},
@@ -126,14 +126,14 @@ RDDB["Battle for Azeroth"] = {
 		274195, -- Corrupted Blood
 		277072, -- Corrupted Gold
 		265914, -- Molten Gold
-		255835, -- Transfusión
-		255836, -- Transfusión
+		255835, -- Transfusiï¿½n
+		255836, -- Transfusiï¿½n
 		},
 		["Vol'kaal"] = {
 		order = 2, ejid = 2036,
 		263927, -- Toxic Pool
 		250372, -- Lingering Nausea
-		255620, -- Erupción purulenta
+		255620, -- Erupciï¿½n purulenta
 		},
 		["Rezan"] = {
 		order = 3, ejid = 2083,
@@ -153,8 +153,8 @@ RDDB["Battle for Azeroth"] = {
 		order = 5, ejid = nil,
 		253562, -- Fuego salvaje
 		254959, -- Quemar alma
-		260668, -- Transfusión
-		255567, -- Carga frenética
+		260668, -- Transfusiï¿½n
+		255567, -- Carga frenï¿½tica
 		279118, -- Maleficio inestable
 		252692, -- Golpe embotador
 		252687, -- Golpe de Venolmillo
@@ -180,7 +180,7 @@ RDDB["Battle for Azeroth"] = {
 		["Lord Stormsong"] = {
 		order = 3, ejid = 2155,
 		268896, -- Mind Rend
-		269104, -- Vacío explosivo
+		269104, -- Vacï¿½o explosivo
 		269131, -- Dominamentes ancestral
 		},
 		["Vol'zith the Whisperer"] = {
@@ -198,7 +198,7 @@ RDDB["Battle for Azeroth"] = {
 		268391, -- Ataque mental
 		274720, -- Golpe abisal
 		276268, -- Golpe tumultuoso
-		268059, -- Ancla de vinculación
+		268059, -- Ancla de vinculaciï¿½n
 		268027, -- Mareas crecientes
 		268214, -- Grabar carne
 		},
@@ -215,7 +215,7 @@ RDDB["Battle for Azeroth"] = {
 		257791, -- Howling Fear
 		257777, -- Chafarote entorpecedor
 		257793, -- Polvo de humo
-		260067, -- Vapuleo sañoso
+		260067, -- Vapuleo saï¿½oso
 		},
 		["Knight Captain Valyri"] = {
 		order = 3, ejid = 2099,
@@ -228,19 +228,19 @@ RDDB["Battle for Azeroth"] = {
 		256038, -- Deadeye
 		256044, -- Deadeye
 		256200, -- Veneno Muerte Diestra
-		256105, -- Ráfaga explosiva
+		256105, -- Rï¿½faga explosiva
 		256201, -- Cartuchos incendiarios
 		},
 		["Trash"] = {
 		order = 5, ejid = nil,
-		258864, -- Fuego de supresión
+		258864, -- Fuego de supresiï¿½n
 		258313, -- Esposar
 		258079, -- Dentellada enorme
 		258075, -- Mordedura irritante
 		258058, -- Exprimir
 		265889, -- Golpe de antorcha
 		258128, -- Grito debilitante
-		225080, -- Reencarnación
+		225080, -- Reencarnaciï¿½n
 		},
 	},
 	[1021] = {
@@ -275,11 +275,11 @@ RDDB["Battle for Azeroth"] = {
 		["Trash"] = {
 		order = 6, ejid = nil,
 		263905, -- Tajo marcador
-		265352, -- Añublo de sapo
+		265352, -- Aï¿½ublo de sapo
 		266036, -- Drenar esencia
-		264105, -- Señal rúnica
-		264390, -- Hechizo de vinculación
-		265346, -- Mirada pálida
+		264105, -- Seï¿½al rï¿½nica
+		264390, -- Hechizo de vinculaciï¿½n
+		265346, -- Mirada pï¿½lida
 		264050, -- Espina infectada
 		265761, -- Tromba espinosa
 		264153, -- Flema
@@ -290,7 +290,7 @@ RDDB["Battle for Azeroth"] = {
 		265881, -- Toque putrefacto
 		264378, -- Fragmentar alma
 		264407, -- Rostro horripilante
-		265880, -- Marca pérfida
+		265880, -- Marca pï¿½rfida
 		265882, -- Pavor persistente
 		266035, -- Astilla de hueso
 		263891, -- Espinas enredadoras
@@ -307,7 +307,7 @@ RDDB["Battle for Azeroth"] = {
 		order = 1, ejid = 2109,
 		256137, -- Timed Detonation
 		257333, -- Shocking Claw
-		262347, -- Pulso estático
+		262347, -- Pulso estï¿½tico
 		270882, -- Azerita llameante
 		},
 		["Azerokk"] = {
@@ -315,13 +315,13 @@ RDDB["Battle for Azeroth"] = {
 		257582, -- Raging Gaze
 		258627, -- Resonant Quake
 		257544, -- Corte dentado
-		275907, -- Machaque tectónico
+		275907, -- Machaque tectï¿½nico
 		},
 		["Rixxa Fluxflame"] = {
 		order = 3, ejid = 2115,
 		258971, -- Azerite Catalyst
 		259940, -- Propellant Blast
-		259853, -- Quemadura química
+		259853, -- Quemadura quï¿½mica
 		},
 		["Mogul Razdunk"] = {
 		order = 4, ejid = 2116,
@@ -333,44 +333,70 @@ RDDB["Battle for Azeroth"] = {
 		["Trash"] = {
 		order = 5, ejid = nil,
 		280604, -- Chorro helado
-		280605, -- Congelación cerebral
+		280605, -- Congelaciï¿½n cerebral
 		263637, -- Tendedero
 		269298, -- Toxina de creaviudas
 		263202, -- Lanza de roca
 		268704, -- Temblor furioso
 		268846, -- Hoja de eco
 		263074, -- Mordedura degenerativa
-		262270, -- Compuesto cáustico
-		262794, -- Latigazo de energía
-		262811, -- Glóbulo parasitario
+		262270, -- Compuesto cï¿½ustico
+		262794, -- Latigazo de energï¿½a
+		262811, -- Glï¿½bulo parasitario
 		268797, -- Transmutar: enemigo en baba
 		269429, -- Disparo cargado
 		262377, -- Buscar y destruir
-		262348, -- Deflagración de mina
-		269092, -- Tromba de artillería
+		262348, -- Deflagraciï¿½n de mina
+		269092, -- Tromba de artillerï¿½a
 		262515, -- Buscacorazones de azerita
 		262513, -- Buscacorazones de azerita
 		},
 	},
 	[1023] = {
 		{ id = 1023, name = "Siege of Boralus" },
-		["Chopper Redhook"] = {
-		order = 1, ejid = 2132,
-		257459, -- On the Hook
-		257288, -- Heavy Slash
+		["Sergeant Bainbridge"] = {
+		order = 1, ejid = 2133,
+		256867, --Heavy Hitter
+		260954, --Iron Gaze
+		257649, --Boiling Rage
+		261428, --Hangman's Noose
+		260924, --Steel Tempest
+		257585, --Cannon Barrage
+		273716, --Heavy Ordnance
+		257292, --Heavy Slash
+		257641, --Molten Slug
 		},
 		["Dread Captain Lockwood"] = {
 		order = 2, ejid = 2173,
-		256076, -- Gut Shot
+		463185, --Mass Bombardment
+		272426, --Sighted Artillery
+		463182, --Fiery Ricochet
+		280389, --Shoot
+		272471, --Evasive
+		273470, --Gut Shot
+		269029, --Clear the Deck
+		268752, --Withdraw
+		268443, --Dread Volley
+		268230, --Crimson Swipe
+		268260, --Broadside
+		268976, --Unstable Ordnance
 		},
 		["Hadal Darkfathom"] = {
 		order = 3, ejid = 2134,
-		257882, -- Break Water
-		257862, -- Crashing Tide
+		261563, --Crashing Tide
+		257882, --Break Water
+		276068, --Tidal Surge
 		},
 		["Viq'Goth"] = {
 		order = 4, ejid = 2140,
-		274991, -- Putrid Waters
+		274991, --Putrid Waters
+		279897, --Terror From Below
+		270624, --Crushing Embrace
+		270185, --Call of the Deep
+		270590, --Hull Cracker
+		269266, --Slam
+		269416, --Blast
+		269484, --Eradication
 		},
 	},
 	[1041] = {

--- a/RaidDebuffsOptions/RaidDebuffsCataclysm.lua
+++ b/RaidDebuffsOptions/RaidDebuffsCataclysm.lua
@@ -308,16 +308,44 @@ RDDB["Cataclysm"] = {
 	[71] = {
 		{ id = 71, name = "Grim Batol" },
 		["General Umbriss"] = {
-		order = 1, ejid = 131,
+		order = 1, ejid = 2617,
+		448847, --Commanding Roar
+		448566, --Shadowflame Breath
+		448882, --Rock Spike
+		448953, --Rumbling Earth
+		447261, --Skullsplitter
 		},
 		["Forgemaster Throngus"] = {
-		order = 2, ejid = 132,
+		order = 2, ejid = 2627,
+		449536, --Molten Pool
+		457664, --Forge Weapon
+		452008, --Blistering Heat
+		449687, --Molten Mace
+		449444, --Molten Flurry
+		449474, --Molten Spark
+		447395, --Fiery Cleave
 		},
 		["Drahga Shadowburner"] = {
-		order = 3, ejid = 133,
+		order = 3, ejid = 2618,
+		448013, --Invocation of Shadowflame
+		82850, --Flaming Fixate
+		75238, --Shadowflame Nova
+		450095, --Curse of Entropy
+		447966, --Shadowflame Bolt
+		456751, --Twilight Buffet
+		456773, --Twilight Wind
+		448105, --Devouring Flame
 		},
 		["Erudax, the Duke of Below"] = {
-		order = 4, ejid = 134,
+		order = 4, ejid = 2619,
+		449939, --Shadow Gale
+		448064, --Abyssal Corruption
+		450077, --Void Surge
+		450087, --Depth's Grasp
+		450088, --Void Infusion
+		456718, --Shadow Corruption
+		456719, --Shadow Wound
+		450100, --Crush
 		},
 	},
 	[70] = {

--- a/RaidDebuffsOptions/RaidDebuffsShadowlands.lua
+++ b/RaidDebuffsOptions/RaidDebuffsShadowlands.lua
@@ -83,15 +83,41 @@ RDDB["Shadowlands"] = {
 		{ id = 1184, name = "Mists of Tirna Scithe" },
 		["Ingra Maloch"] = {
 		order = 1, ejid = 2400,
-		323250, -- Charco de ánima
+		321005, --Soul Shackle
+		323138, --Force Compliance
+		323057, --Spirit Bolt
+		328756, --Repulsive Visage
+		323149, --Embrace Darkness
+		323146, --Death Shroud
+		323137, --Bewildering Pollen
+		323177, --Tears of the Forest
+		323250, --Anima Puddle
+		331440, --Weakened Resolve
+		323059, --Droman's Wrath
 		},
 		["Mistcaller"] = {
 		order = 2, ejid = 2402,
-		321828, -- Palmas palmitas
+		321471, --Guessing Game
+		321669, --Penalizing Burst
+		321837, --Oopsie
+		321834, --Dodge Ball
+		321828, --Patty Cake
+		321873, --Freeze Tag
+		321891, --Freeze Tag Fixation
+		321893, --Freezing Burst
 		},
 		["Tred'ova"] = {
 		order = 3, ejid = 2405,
-		322648, -- Vínculo mental
+		463602, --Coalescing Poison
+		322450, --Consumption
+		322527, --Gorging Shield
+		322465, --Anima Rejection
+		326263, --Anima Shedding
+		322550, --Accelerated Incubation
+		326308, --Decomposition Pool
+		322614, --Mind Link
+		322563, --Marked Prey
+		322655, --Acid Expulsion
 		},
 		["Trash"] = {
 		order = 4, ejid = nil,
@@ -218,25 +244,52 @@ RDDB["Shadowlands"] = {
 		{ id = 1182, name = "The Necrotic Wake" },
 		["Blightbone"] = {
 		order = 1, ejid = 2395,
-		320596, -- Arcadas fulminantes
-		320717, -- Hambre de sangre
+		320596, --Heaving Retch
+		320614, --Blood Gorge
+		320631, --Carrion Eruption
+		328146, --Fetid Gas
+		320655, --Crunch
 		},
 		["Amarth, The Harvester"] = {
 		order = 2, ejid = 2391,
-		320170, -- Descarga necrótica
-		333633, -- Ecos torturados
+		321226, --Land of the Dead
+		333602, --Frostbolt
+		328664, --Chilled
+		333623, --Frostbolt Volley
+		319997, --Shoot
+		321247, --Final Harvest
+		333633, --Tortured Echoes
+		333493, --Necrotic Breath
+		333492, --Necrotic Ichor
+		320012, --Unholy Frenzy
+		320170, --Necrotic Bolt
 		},
 		["Surgeon Stitchflesh"] = {
 		order = 3, ejid = 2392,
-		320200, -- Coseaguja
-		322548, -- Gancho de carnicero
-		320366, -- Icor embalsamante
+		327100, --Noxious Fog
+		320358, --Awaken Creation
+		322681, --Meat Hook
+		320376, --Mutilate
+		334321, --Festering Rot
+		327664, --Embalming Ichor
+		320200, --Stitchneedle
+		334488, --Sever Flesh
+		343555, --Morbid Fixation
+		320359, --Escape
 		},
 		["Nalthor the Rimebinder"] = {
 		order = 4, ejid = 2396,
-		320784, -- Lluvia de cometas
-		320788, -- Ataduras congeladas
-		322274, -- Socavar
+		320784, --Comet Storm
+		321368, --Icebound Aegis
+		320788, --Frozen Binds
+		320771, --Icy Shard
+		321894, --Dark Exile
+		328181, --Frigid Cold
+		328212, --Razorshard Ice
+		287294, --Blizzard
+		287295, --Chilled
+		322274, --Enfeeble
+		345323, --Champion's Boon
 		},
 		["Trash"] = {
 		order = 5, ejid = nil,

--- a/RaidDebuffsOptions/RaidDebuffsTheWarWithin.lua
+++ b/RaidDebuffsOptions/RaidDebuffsTheWarWithin.lua
@@ -17,18 +17,19 @@ RDDB["The War Within"] = {
 		},
 		["Anub'zekt"] = {
 		order = 2, ejid = 2584,
-		433425, --Impale
-		433677, --Burrow Charge
+		433766, --Eye of the Swarm
+		442210, --Silken Restraints
 		433740, --Infestation
 		433747, --Ceaseless Swarm
-		433766, --Eye of the Swarm
-		442210, --Web Wrap
+		433677, --Burrow Charge
+		433425, --Impale
 		},
 		["Ki'katal the Harvester"] = {
 		order = 3, ejid = 2585,
 		432031, --Grasping Blood
 		432117, --Cosmic Singularity
 		432119, --Faded
+		461487, --Cultivated Poisons
 		432227, --Venom Volley
 		432130, --Erupting Webs
 		},
@@ -88,8 +89,8 @@ RDDB["The War Within"] = {
 		},
 		["Fangs of the Queen"] = {
 		order = 2, ejid = 2595,
-		439522, --Synergic Step
 		439518, --Twin Fangs
+		439522, --Synergic Step
 		439621, --Shade Slash
 		439637, --Echoing Shade
 		439692, --Duskbringer
@@ -98,15 +99,14 @@ RDDB["The War Within"] = {
 		440468, --Rime Dagger
 		440470, --Freezing Blood
 		458741, --Frozen Solid
-		440420, --Dark Paranoia
-		440419, --Shadow Shunpo
 		},
 		["The Coaglamation"] = {
 		order = 3, ejid = 2600,
 		441216, --Viscous Darkness
 		442285, --Corrupted Coating
+		461842, --Oozing Smash
+		461880, --Blood Surge
 		437533, --Dark Pulse
-		445435, --Blood Surge
 		},
 		["Izo, the Grand Splicer"] = {
 		order = 4, ejid = 2596,
@@ -203,9 +203,12 @@ RDDB["The War Within"] = {
 	},
 	[1270] = {
 		{ id = 1270, name = "The Dawnbreaker" },
-		["Shadowcrown"] = {
+		["Speaker Shadowcrown"] = {
 		order = 1, ejid = 2580,
 		451026, --Darkness Comes
+		449042, --Radiant Light
+		449332, --Encroaching Shadows
+		452001, --Light Fragment
 		425264, --Obsidian Blast
 		453212, --Obsidian Beam
 		426712, --Collapsing Darkness
@@ -216,33 +219,33 @@ RDDB["The War Within"] = {
 		},
 		["Anub'ikkaj"] = {
 		order = 2, ejid = 2581,
-		427001, --Terrifying Slam
+		427192, --Empowered Might
 		426860, --Dark Orb
 		427378, --Dark Scars
+		427001, --Terrifying Slam
 		426787, --Shadowy Decay
 		452127, --Animate Shadows
 		452099, --Congealed Darkness
-		427192, --Empowered Might
 		},
 		["Rasha'nan"] = {
 		order = 3, ejid = 2593,
-		434655, --Arathi Bomb
-		434726, --Blazing
-		434668, --Carrying Arathi Bomb
-		434669, --Drop Arathi Bomb
+		434655, --Arathi Bombs
+		434668, --Sparking Arathi Bomb
 		438946, --Throw Arathi Bomb
 		434407, --Rolling Acid
-		434576, --Acidic Stupor
 		434579, --Corrosion
+		434576, --Acidic Stupor
 		448213, --Expel Webs
 		448888, --Erosive Spray
+		463428, --Lingering Erosion
 		449042, --Radiant Light
+		449332, --Encroaching Shadows
 		452001, --Light Fragment
 		449734, --Acidic Eruption
 		434089, --Spinneret's Strands
 		434119, --Spinneret's Websnap
 		434096, --Sticky Webs
-		438957, --Acid Pool
+		438957, --Acid Pools
 		435793, --Tacky Burst
 		},
 	},
@@ -285,38 +288,36 @@ RDDB["The War Within"] = {
 		{ id = 1269, name = "The Stonevault" },
 		["E.D.N.A."] = {
 		order = 1, ejid = 2572,
+		424903, --Volatile Spike
 		424805, --Refracting Beam
 		424879, --Earth Shatterer
 		424888, --Seismic Smash
 		424889, --Seismic Reverberation
-		424893, --Earth Shield
-		424903, --Volatile Spike
+		424893, --Stone Shield
 		},
 		["Skarmorak"] = {
 		order = 2, ejid = 2579,
-		422233, --Crystalline Smash
-		426215, --Reclaim
-		443494, --Crystalline Eruption
-		423228, --Crumbling Shell
-		423246, --Shattered Shell
+		423200, --Fortified Shell
 		423324, --Void Discharge
+		422233, --Crystalline Smash
+		443494, --Crystalline Eruption
 		423538, --Unstable Crash
-		443405, --Void Fragment
-		423572, --Void Empowerment
+		443405, --Unstable Fragments
+		435813, --Unstable Energy
 		},
-		["Master Machinists Brokk and Dorlita"] = {
+		["Master Machinists"] = {
 		order = 3, ejid = 2590,
 		439577, --Silenced Speaker
-		428239, --Activate Ventilation
-		428819, --Exhaust Vents
-		430000, --Flaming Scrap
-		428161, --Molten Metal
+		443954, --Exhaust Vents
+		429999, --Flaming Scrap
 		428202, --Scrap Song
-		428555, --Scrap Cube
-		428508, --Deconstruction
-		428535, --Metal Splinters
-		428711, --Molten Hammer
-		428120, --Lava Expulsion
+		428547, --Scrap Cube
+		428161, --Molten Metal
+		428508, --Blazing Crescendo
+		464392, --Blazing Shrapnel
+		463057, --Magma Wave
+		428711, --Igneous Hammer
+		428120, --Lava Cannon
 		},
 		["Void Speaker Eirich"] = {
 		order = 4, ejid = 2582,
@@ -325,6 +326,283 @@ RDDB["The War Within"] = {
 		427854, --Entropic Reckoning
 		457465, --Entropy
 		427869, --Unbridled Void
+		},
+	},
+	-- Raid instances
+	[1278] = {
+		{ id = 1278, name = "Khaz Algar", raid = true },
+		["Kordac, the Dormant Protector"] = {
+		order = 1, ejid = 2637,
+		458423, --Arcane Bombardment
+		458209, --Overcharged Lasers
+		458799, --Overcharged Earth
+		459281, --Empowering Coalescence
+		458320, --Titanic Impact
+		458838, --Supression Burst
+		},
+		["Aggregation of Horrors"] = {
+		order = 2, ejid = 2635,
+		452210, --Crystalline Barrage
+		453271, --Dark Awakening
+		452981, --Voidquake
+		453294, --Crystal Strike
+		456148, --Annihilation Barrage
+		},
+		["Shurrai, Atrocity of the Undersea"] = {
+		order = 3, ejid = 2636,
+		453607, --Abyssal Strike
+		453733, --Briny Vomit
+		455275, --Dark Tide
+		453875, --Regurgitate Souls
+		455639, --Shroud of the Drowned
+		453863, --Ocean's Reckoning
+		},
+		["Orta, the Broken Mountain"] = {
+		order = 4, ejid = 2625,
+		450454, --Tectonic Roar
+		450407, --Colossal Slam
+		450677, --Rupturing Runes
+		450929, --Mountain's Grasp
+		451702, --Discard Weaklings
+		},
+	},
+	[1273] = {
+		{ id = 1273, name = "Nerub-ar Palace", raid = true },
+		["Ulgrax the Devourer"] = {
+		order = 1, ejid = 2607,
+		434776, --Carnivorous Contest
+		440904, --Devour
+		455847, --Battered and Bruised
+		440849, --Contemptful Rage
+		441451, --Stalker's Webbing
+		439419, --Stalker's Netting
+		455831, --Hardened Netting
+		435138, --Digestive Acid
+		435136, --Venomous Lash
+		434697, --Brutal Crush
+		434705, --Tenderized
+		435341, --Hulking Crash
+		440177, --Ready to Feed
+		438012, --Hungering Bellows
+		438041, --Insatiable Rage
+		436255, --Juggernaut Charge
+		439037, --Disembowel
+		438657, --Chunky Viscera
+		438324, --Feed
+		455870, --Bioactive Spines
+		443842, --Swallowing Darkness
+		},
+		["The Bloodbound Horror"] = {
+		order = 2, ejid = 2611,
+		444363, --Gruesome Disgorge
+		462306, --The Unseeming
+		451288, --Black Bulwark
+		445016, --Spectral Slam
+		445174, --Manifest Horror
+		445257, --Blood Pact
+		445570, --Unseeming Blight
+		452237, --Bloodcurdle
+		445936, --Spewing Hemorrhage
+		442530, --Goresplatter
+		461876, --Seeping Transfusion
+		443305, --Crimson Rain
+		443042, --Grasp From Beyond
+		438696, --Black Sepsis
+		},
+		["Sikran, Captain of the Sureki"] = {
+		order = 3, ejid = 2599,
+		433475, --Phase Blades
+		458272, --Cosmic Simulacrum
+		459273, --Cosmic Shards
+		459785, --Cosmic Residue
+		461401, --Collapsing Nova
+		442428, --Decimate
+		456420, --Shattering Sweep
+		439511, --Captain's Flourish
+		435401, --Expose
+		432969, --Phase Lunge
+		439559, --Rain of Arrows
+		},
+		["Rasha'nan"] = {
+		order = 4, ejid = 2609,
+		439789, --Rolling Acid
+		439785, --Corrosion
+		439787, --Acidic Stupor
+		439776, --Acid Pools
+		439784, --Spinneret's Strands
+		439778, --Spinneret's Websnap
+		460789, --Tacky Threads
+		439780, --Sticky Webs
+		439815, --Infested Spawn
+		455287, --Infested Bite
+		454989, --Enveloping Webs
+		444687, --Savage Assault
+		458067, --Savage Wound
+		439795, --Web Reave
+		439811, --Erosive Spray
+		440193, --Lingering Erosion
+		452806, --Acidic Eruption
+		457877, --Acidic Carapace
+		444094, --Caustic Hail
+		439792, --Tacky Burst
+		},
+		["Broodtwister Ovi'nax"] = {
+		order = 5, ejid = 2612,
+		442526, --Experimental Dosage
+		446694, --Mutation: Necrotic
+		438807, --Vicious Bite
+		458212, --Necrotic Wound
+		446690, --Mutation: Ravenous
+		446700, --Poison Burst
+		442263, --Mutation: Accelerated
+		442251, --Fixate
+		442257, --Infest
+		442430, --Ingest Black Blood
+		450362, --Unstable Infusion
+		441612, --Vile Discharge
+		452802, --Catalyze Mutation
+		442799, --Sanguine Overflow
+		450661, --Caustic Reaction
+		446349, --Sticky Web
+		446351, --Web Eruption
+		441362, --Volatile Concoction
+		},
+		["Nexus-Princess Ky'veza"] = {
+		order = 6, ejid = 2601,
+		436867, --Assassination
+		437343, --Queensbane
+		439409, --Dark Viscera
+		437620, --Nether Rift
+		437786, --Atomized
+		439576, --Nexus Daggers
+		436950, --Stalking Shadows
+		448364, --Death Masks
+		447174, --Death Cloak
+		438245, --Twilight Massacre
+		436749, --Reaper
+		440377, --Void Shredders
+		440576, --Chasmal Gash
+		435414, --Starless Night
+		442278, --Eternal Night
+		435486, --Regicide
+		434645, --Eclipse
+		},
+		["The Silken Court"] = {
+		order = 7, ejid = 2608,
+		455796, --Whispers of The Silken Court
+		455849, --Mark of Paranoia
+		460357, --Mote of Overwrought Paranoia
+		460359, --Void Degeneration
+		455850, --Mark of Rage
+		460263, --Mote of Unrelenting Rage
+		460281, --Burning Rage
+		455863, --Mark of Death
+		455363, --Queen's Proclamation
+		440158, --Reckless Charge
+		460360, --Burrowed Eruption
+		438801, --Call of the Swarm
+		438706, --Harden Carapace
+		438773, --Shattered Shell
+		455080, --Scarab Lord's Perseverance
+		440504, --Impaling Eruption
+		449857, --Impaled
+		438218, --Piercing Strike
+		439992, --Web Bomb
+		440001, --Binding Webs
+		440179, --Entangled
+		438656, --Venomous Rain
+		450045, --Skittering Leap
+		438200, --Poison Bolt
+		450980, --Shatter Existence
+		460600, --Entropic Barrage
+		463461, --Entropic Vulnerability
+		438677, --Stinging Swarm
+		449993, --Stinging Burst
+		456235, --Stinging Delirium
+		438355, --Cataclysmic Entropy
+		441634, --Web Vortex
+		450129, --Entropic Desolation
+		441782, --Strands of Reality
+		450483, --Void Step
+		441772, --Void Bolt
+		451277, --Spike Storm
+		460364, --Seismic Upheaval
+		463464, --Seismic Vulnerability
+		443092, --Spike Eruption
+		443063, --Unleashed Swarm
+		},
+		["Queen Ansurek"] = {
+		order = 8, ejid = 2602,
+		437592, --Reactive Toxin
+		438846, --Reactive Froth
+		451278, --Concentrated Toxin
+		464628, --Reaction Trauma
+		464638, --Frothy Toxin
+		464643, --Lingering Toxin
+		460133, --Toxic Reaction
+		438481, --Toxic Waves
+		437078, --Acid
+		437417, --Venom Nova
+		441556, --Reaction Vapor
+		439814, --Silken Tomb
+		441958, --Grasping Silk
+		440899, --Liquefy
+		441084, --Acid Explosion
+		437093, --Feast
+		439299, --Web Blades
+		440607, --Acrid Presence
+		447076, --Predation
+		447170, --Predation Threads
+		447456, --Paralyzing Venom
+		451607, --Paralyzing Waves
+		447411, --Wrest
+		447240, --Devour
+		460366, --Shadowgate
+		464056, --Gloom Touch
+		447983, --Gloom Blast
+		443403, --Gloom
+		460218, --Shadowy Distortion
+		448660, --Acid Bolt
+		449940, --Acidic Apocalypse
+		447950, --Shadowblast
+		447999, --Radiating Gloom
+		448176, --Gloom Orbs
+		448046, --Gloom Eruption
+		448300, --Echoing Connection
+		448488, --Worshipper's Protection
+		462541, --Cosmic Rupture
+		464799, --Lingering Fallout
+		462564, --Cosmic Fallout
+		448458, --Cosmic Apocalypse
+		448147, --Oust
+		460315, --Ousting Fragments
+		451600, --Expulsion Beam
+		455374, --Dark Detonation
+		449235, --Caustic Fangs
+		443888, --Abyssal Infusion
+		443915, --Abyssal Conduit
+		455387, --Abyssal Reverberation
+		444507, --Conduit Ejections
+		444502, --Conduit Collapse
+		445422, --Frothing Gluttony
+		445623, --Glutton Threads
+		445877, --Froth Vapor
+		461408, --Consume
+		444829, --Queen's Summons
+		445152, --Acolyte's Essence
+		446012, --Essence Scarred
+		445013, --Dark Barrier
+		445021, --Null Detonation
+		438976, --Royal Condemnation
+		441865, --Royal Shackles
+		441872, --Royal Cocoon
+		443325, --Infest
+		443667, --Infested Gloomburst
+		443720, --Gloom Hatchling
+		443336, --Gorge
+		443396, --Gloom Splatter
+		445268, --Dreadful Presence
+		451832, --Cataclysmic Evolution
 		},
 	},
 }


### PR DESCRIPTION
- Add the Raids for Season 1
- Update old dungeons with Season 1 encounter ids and abilities (especially Grim Batol)
- Some minor changes to Season 1 TWW dungeons in recent beta builds