### PR TITLE
Feature: add option to filter raid debuffs from debuff statuses

### DIFF
--- a/Options/modules/statuses/StatusAuraDebuffs.lua
+++ b/Options/modules/statuses/StatusAuraDebuffs.lua
@@ -1,6 +1,6 @@
 local L = Grid2Options.L
 
-local FILTERS = { 'filterDispelDebuffs', 'filterTyped', 'filterBossDebuffs', 'filterPermaDebuffs', 'filterLongDebuffs', 'filterCaster', 'filterRelevant' }
+local FILTERS = { 'filterDispelDebuffs', 'filterTyped', 'filterBossDebuffs', 'filterPermaDebuffs', 'filterLongDebuffs', 'filterCaster', 'filterRelevant', 'filterRaidDebuffs' }
 local MT = {
 	['nil']   = { [1] = true, [2] = false }, -- nil   setting
 	['false'] = { [1] = true, [2] = nil   }, -- false setting
@@ -100,6 +100,24 @@ function Grid2Options:MakeStatusDebuffsFilterOptions(status, options, optionPara
 		"Non Self Casted",
 		"Display non self debuffs"
 	)
+	options.filterRaidDebuffs = {
+		type = "toggle",
+		name = L["Remove Raid Debuffs"],
+		desc = L["Do not display debuffs found in the Raid Debuffs module."],
+		order = order + 0.1,
+		get = function ()
+		   return status.dbx.filterRaidDebuffs
+		end,
+		set = function (_, v)
+			if v then
+				status.dbx.filterRaidDebuffs = true
+			else
+				status.dbx.filterRaidDebuffs = nil
+			end
+		    status:Refresh()
+		end,
+		hidden = IsHidden,
+	}
 	options.useWhiteList = {
 		type = "toggle",
 		name = L["Whitelist"],

--- a/RaidDebuffs/Grid2RaidDebuffs.lua
+++ b/RaidDebuffs/Grid2RaidDebuffs.lua
@@ -75,6 +75,12 @@ local unit_in_roster = Grid2.roster_guids
 -- debuffs type colors table
 local debuffTypeColors = Grid2.debuffTypeColors
 
+-- Surface method to fetch raid debuffs from main addon
+local function GetRaidDebuffs()
+	return spells_order
+end
+Grid2.GetRaidDebuffs = GetRaidDebuffs
+
 -- GSRD
 local function RefreshAuras(self, event, unit)
 	if unit_in_roster[unit] then


### PR DESCRIPTION
Hi @michaelnpsp ,

First off, thank you for your work on this addon. Grid2 is crucial piece of the puzzle for healers and it's capabilities for customization allow for extremely bespoke environments. However one feature that I have been wanting is a way to easily filter out enabled Raid Debuffs from regular Debuff status groups. It appears I am not the only one who has requested this per https://github.com/michaelnpsp/Grid2/issues/132.

The value of this is more apparent with my configuration which is as follows:

1. Icon indicator in center of frame with Raid Debuff status associated
2. Icon indicator in bottom left of frame with generic Debuffs status associated

With the above configuration any applied debuff aura that is present and enabled in the Raid Debuffs module would display both indicators. What this results in is a cluttered frame with duplicated information. However it is nice to have important Raid debuffs prominent in the center, while other debuffs in the corner.

One workaround that I've been using for a few months is a long blacklist for indicator 2, however this requires parsing out the auras defined in the Raid Debuffs module and putting those into the blacklist. This is a tedious process and requires upkeep as new seasons are released.

This PR introduces the desired functionality and surfaces it in the Debuffs status configuration page. A single toggle is presented to the user, where when enabled will prevent any enabled raid debuffs from being shown on the associated indicator.

![image](https://github.com/user-attachments/assets/99740b89-3a52-4f18-bb6c-92aa8ce8f272)
In the above image has indicators matching my description above. The center aura is an enabled Raid debuff, the aura in the bottom left is a disabled Raid debuff. This exemplifies the desired behavior of having enabled Raid debuffs filtered out of the generic Debuffs group.

![image](https://github.com/user-attachments/assets/f844afb5-e9a8-4c15-8201-ab62cc08d55d)
And here is the configuration page.

I tested the following cases and am happy to test out any that you can recommend.

| Test | Outcome |
|--------|--------|
| Upgrade Grid2 from latest version to new release | Existing profiles show the setting as disabled (retains existing functionality for users upon upgrade) |
| Enabling "Remove Raid Debuffs", enabling a Raid debuff, get debuff applied | Debuffs status indicator does *not* show the Raid debuff aura |
| Enabling "Remove Raid Debuffs", disabling a Raid debuff, get debuff applied | Debuffs status indicator *does* show the Raid debuff aura |
| Disabling "Remove Raid Debuffs", enabling a Raid debuff, get debuff applied | Debuffs status indicator *does* show the Raid debuff aura | 
| Reload and relog after changing setting from Disabled -> Enabled|Enabled setting is persisted|

I'd love to get this merged and will iterate as needed. Looking forward to hearing back from you!
