### PR TITLE
feat: change max value for icons to 9

### DIFF
--- a/Options/modules/indicators/IndicatorIcons.lua
+++ b/Options/modules/indicators/IndicatorIcons.lua
@@ -139,7 +139,7 @@ function Grid2Options:MakeIndicatorAuraIconsSizeOptions(indicator, options, opti
 		name = L["Max Icons"],
 		desc = L["Select maximum number of icons to display."],
 		min = 1,
-		max = 6,
+		max = 9,
 		step = 1,
 		get = function () return indicator.dbx.maxIcons or 3 end,
 		set = function (_, v)


### PR DESCRIPTION
My rdruid has a lot of hots and I modified the code locally to show more, figured this would probably be nice to have in the addon since I didn't find any technical reasons it wouldn't work.