### PR TITLE
Option to change the blend mode for glow lines in multi bars

### DIFF
--- a/Options/modules/indicators/IndicatorMultiBar.lua
+++ b/Options/modules/indicators/IndicatorMultiBar.lua
@@ -2,6 +2,7 @@
 
 local Grid2Options = Grid2Options
 local L = Grid2Options.L
+local BLEND_VALUES = { L["Default"] , L["Additive"] }
 
 Grid2Options:RegisterIndicatorOptions("multibar", true, function(self, indicator)
 	local layout, filter = {}, {}, {}
@@ -489,6 +490,31 @@ do
 			end,
 			values = TILE_BAR_VALUES,
 			hidden = false,
+		},
+
+		-------------------------------------------------------------------------
+
+		headerAppearance = {
+			type = "header",
+			hidden = function() return not barDbx.glowLine end,
+			order = 14,
+			name = L["Appearance"]
+		},
+
+		lineBlendMode = {
+			type = "select",
+			hidden = function() return not barDbx.glowLine end,
+			order = 15,
+			name = L["Blend Mode"],
+			desc = L["Select how to mix the texture with the background."],
+			get = function () return (barDbx.lineBlendMode=='BLEND') and 1 or 2 end,
+			set = function (_, v)
+				barDbx.lineBlendMode = (v==2) and 'ADD' or 'BLEND'
+				self:RefreshIndicator(indicator, "Layout")
+				if v==2 then barDbx.lineBlendMode = nil end
+				self:RefreshIndicator(indicator, "Layout")
+			end,
+			values = BLEND_VALUES,
 		},
 
 		-------------------------------------------------------------------------

--- a/modules/IndicatorMultiBar.lua
+++ b/modules/IndicatorMultiBar.lua
@@ -162,7 +162,7 @@ local function Bar_Layout(self, parent)
 		texture:SetHorizTile(setup.horWrap~='CLAMP')
 		texture:SetVertTile(setup.verWrap~='CLAMP')
 		texture:SetDrawLayer("ARTWORK", setup.sublayer)
-		texture:SetBlendMode(setup.lineSize and 'ADD' or 'BLEND')
+		texture:SetBlendMode(setup.lineBlendMode or 'BLEND')
 		local c = setup.color
 		if c then
 			texture:SetVertexColor( c.r, c.g, c.b, setup.opacity )
@@ -259,6 +259,7 @@ local function Bar_UpdateDB(self)
 			sublayer  = setup.glowLine and 7 or i,
 			lineSize  = setup.glowLine,
 			lineAdjust= setup.glowLine and (setup.glowLineAdjust or 0) or nil,
+			lineBlendMode = setup.glowLine and (setup.lineBlendMode or "ADD") or nil,
 		}
 	end
 	if backColor then


### PR DESCRIPTION
Similar to the blend mode option in texture indicators.

By default glow lines use the `ADD` blend mode, but it makes dark colors transparent, so it doesn't work with all textures or when you'd like to use the line as a divider between health and deficit, which is very handy for healers who color their health by the color of their active hots and lose contrast with the background color.

<img width="257" height="307" alt="Screenshot 2025-09-16 at 12 14 50" src="https://github.com/user-attachments/assets/81a4e464-d5ff-4a98-ba6e-0d3eb89fe3f2" />
<img width="157" height="97" alt="Screenshot 2025-09-16 at 12 28 18" src="https://github.com/user-attachments/assets/c099e747-a4e6-4188-997d-5fc6fe97a910" />


