### PR TITLE
(Feature) Support custom placement of cooldown text

### DIFF
--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -745,6 +745,55 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 		 end,
 		hidden= function() return indicator.dbx.enableCooldownText==nil end,
 	}
+	options.ctFontJustify = {
+		type = 'select',
+		order = 144,
+		name = L["Text Location"],
+		desc = L["Text Location"],
+		values = Grid2Options.pointValueList,
+		get = function()
+            local JustifyH = indicator.dbx.ctFontJustifyH or "CENTER"
+            local JustifyV = indicator.dbx.ctFontJustifyV or "MIDDLE"
+            return self.pointMapText[ JustifyH..JustifyV ]
+		end,
+		set = function(_, v)
+            local justify =  self.pointMapText[v]
+            indicator.dbx.ctFontJustifyH = justify[1]
+            indicator.dbx.ctFontJustifyV = justify[2]
+            self:RefreshIndicator( indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
+	options.ctFontOffsetX = {
+		type = "range",
+		order = 145,
+		name = L["X Offset"],
+		desc = L["Adjust the horizontal offset of the text"],
+		softMin  = -50,
+		softMax = 50,
+		step = 1,
+		get = function () return indicator.dbx.ctFontOffsetX or 0	end,
+		set = function (_, v)
+			indicator.dbx.ctFontOffsetX = v
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
+	options.ctFontOffsetY = {
+		type = "range",
+		order = 146,
+		name = L["Y Offset"],
+		desc = L["Adjust the vertical offset of the text"],
+		softMin  = -50,
+		softMax = 50,
+		step = 1,
+		get = function () return indicator.dbx.ctFontOffsetY or 0	end,
+		set = function (_, v)
+			indicator.dbx.ctFontOffsetY = v
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
 end
 
 -- Grid2Options:MakeIndicatorTooltipsOptions()

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -160,6 +160,8 @@ local function Icon_Layout(self, parent)
 		local color, text = self.ctColor, f.Cooldown:GetCountdownFontString()
 		text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
 		text:SetTextColor(color.r, color.g, color.b, color.a)
+		text:ClearAllPoints()
+		text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 	end
 
 	if not self.disableStack then

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -220,6 +220,8 @@ local function Icon_Layout(self, parent)
 				local color, text = self.ctColor, frame.cooldown:GetCountdownFontString()
 				text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
 				text:SetTextColor(color.r, color.g, color.b, color.a)
+				text:ClearAllPoints()
+				text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 				text:SetMaxLines(1)
 			end
 			frame.cooldown:Show()


### PR DESCRIPTION
Hello!

Thanks for this addon and the continued support. While setting up my UI during prepatch, I noticed that OmniCC is not continuing to be supported for prepatch and Midnight releases. However one key feature of OmniCC was being able to modify the placement of cooldown text on particular frames using rules (to avoid impacting other frames). This PR introduces the functionality to move cooldown text using similar configuration values as the stack text, namely justification and x/y offsets.

I've tested this on Retail Version: 12.0.0.65560.

I'm happy to iterate as needed to get this merged.

Thanks!