### PR TITLE
(Feature) Revisit support custom placement of cooldown text

### DIFF
--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -745,6 +745,55 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 		 end,
 		hidden= function() return indicator.dbx.enableCooldownText==nil end,
 	}
+	options.ctFontJustify = {
+		type = 'select',
+		order = 144,
+		name = L["Text Location"],
+		desc = L["Text Location"],
+		values = Grid2Options.pointValueList,
+		get = function()
+            local JustifyH = indicator.dbx.ctFontJustifyH or "CENTER"
+            local JustifyV = indicator.dbx.ctFontJustifyV or "MIDDLE"
+            return self.pointMapText[ JustifyH..JustifyV ]
+		end,
+		set = function(_, v)
+            local justify =  self.pointMapText[v]
+            indicator.dbx.ctFontJustifyH = justify[1]
+            indicator.dbx.ctFontJustifyV = justify[2]
+            self:RefreshIndicator( indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
+	options.ctFontOffsetX = {
+		type = "range",
+		order = 145,
+		name = L["X Offset"],
+		desc = L["Adjust the horizontal offset of the text"],
+		softMin  = -50,
+		softMax = 50,
+		step = 1,
+		get = function () return indicator.dbx.ctFontOffsetX or 0	end,
+		set = function (_, v)
+			indicator.dbx.ctFontOffsetX = v
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
+	options.ctFontOffsetY = {
+		type = "range",
+		order = 146,
+		name = L["Y Offset"],
+		desc = L["Adjust the vertical offset of the text"],
+		softMin  = -50,
+		softMax = 50,
+		step = 1,
+		get = function () return indicator.dbx.ctFontOffsetY or 0	end,
+		set = function (_, v)
+			indicator.dbx.ctFontOffsetY = v
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+		hidden= function() return indicator.dbx.enableCooldownText==nil end,
+	}
 end
 
 -- Grid2Options:MakeIndicatorTooltipsOptions()

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -160,6 +160,8 @@ local function Icon_Layout(self, parent)
 		local color, text = self.ctColor, f.Cooldown:GetCountdownFontString()
 		text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
 		text:SetTextColor(color.r, color.g, color.b, color.a)
+		text:ClearAllPoints()
+		text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 	end
 
 	if not self.disableStack then
@@ -207,10 +209,14 @@ local function Icon_UpdateDB(self)
 	-- ignore icon and use a solid square texture
 	self.disableIcon  = dbx.disableIcon
 	-- cooldown text
+	local ctJV,ctJH      = dbx.ctFontJustifyV or 'MIDDLE', dbx.ctFontJustifyH or 'CENTER'
 	self.ctFontFlags     = dbx.ctFontFlags or "OUTLINE"
 	self.ctFontSize      = dbx.ctFontSize or 9
 	self.ctFont          = Grid2:MediaFetch("font", dbx.ctFont or theme.font) or STANDARD_TEXT_FONT
 	self.ctColor         = Grid2:MakeColor(dbx.ctColor, "WHITE")
+	self.ctFontPoint     = (ctJV=='MIDDLE' and ctJH) or (ctJH=='CENTER' and ctJV) or ctJV..ctJH
+	self.ctFontOffsetX   = dbx.ctFontOffsetX or 0
+	self.ctFontOffsetY   = dbx.ctFontOffsetY or 0
 	-- backdrop
 	self.backdrop = Grid2:GetBackdropTable("Interface\\Addons\\Grid2\\media\\white16x16", self.borderSize or 1)
 end

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -220,6 +220,8 @@ local function Icon_Layout(self, parent)
 				local color, text = self.ctColor, frame.cooldown:GetCountdownFontString()
 				text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
 				text:SetTextColor(color.r, color.g, color.b, color.a)
+				text:ClearAllPoints()
+				text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 				text:SetMaxLines(1)
 			end
 			frame.cooldown:Show()
@@ -297,10 +299,14 @@ local function Icon_UpdateDB(self)
 	self.font            = Grid2:MediaFetch("font", dbx.font or theme.font) or STANDARD_TEXT_FONT
 	self.colorStack      = Grid2:MakeColor(dbx.colorStack, "WHITE")
 	-- cooldown text
+	local ctJV,ctJH      = dbx.ctFontJustifyV or 'MIDDLE', dbx.ctFontJustifyH or 'CENTER'
 	self.ctFontFlags     = dbx.ctFontFlags or "OUTLINE"
 	self.ctFontSize      = dbx.ctFontSize or 9
 	self.ctFont          = Grid2:MediaFetch("font", dbx.ctFont or theme.font) or STANDARD_TEXT_FONT
 	self.ctColor         = Grid2:MakeColor(dbx.ctColor, "WHITE")
+	self.ctFontPoint     = (ctJV=='MIDDLE' and ctJH) or (ctJH=='CENTER' and ctJV) or ctJV..ctJH
+	self.ctFontOffsetX   = dbx.ctFontOffsetX or 0
+	self.ctFontOffsetY   = dbx.ctFontOffsetY or 0
 	-- backdrop
 	self.backdrop = self.borderSize>0 and Grid2:GetBackdropTable("Interface\\Addons\\Grid2\\media\\white16x16", self.borderSize) or nil
 end


### PR DESCRIPTION
Apologies for the missed code originally, the assignment of the indicator properties was in my git index but not pushed. This should be complete and functional now and verified with the following steps

* Fetched release.sh from https://github.com/BigWigsMods/packager (saw that is how the existing add in built from the Github actions config
* Ran a local release in my forked repo
```sh
./release.sh -g retail -m .pkgmeta-retail -d
```
* Symlinked the resulting addon directories to my local WoW addons folder
```sh
$ ln -sf ~/_dev/Grid2/.release/Grid2 Grid2
$ ln -sf ~/_dev/Grid2/.release/Grid2Options Grid2Options
$ ln -sf ~/_dev/Grid2/.release/Grid2LDB Grid2LDB
```
* Reloaded WoW and verified no Lua errors in Bugsack

*Previous MR description for completeness:*
Thanks for this addon and the continued support. While setting up my UI during prepatch, I noticed that OmniCC is not continuing to be supported for prepatch and Midnight releases. However one key feature of OmniCC was being able to modify the placement of cooldown text on particular frames using rules (to avoid impacting other frames). This PR introduces the functionality to move cooldown text using similar configuration values as the stack text, namely justification and x/y offsets.

I've tested this on Retail Version: 12.0.0.65560.

I'm happy to iterate as needed to get this merged.

Thanks!
