### PR TITLE
(Feature) Added "Draw Edge" option to icon indicators.

### DIFF
--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -583,6 +583,19 @@ function Grid2Options:MakeIndicatorCooldownAnimOptions(indicator, options)
 		end,
 		hidden= function() return indicator.dbx.disableCooldown end,
 	}
+	options.drawEdge = {
+		type = "toggle",
+		order = 212,
+		name = L["Draw Edge"],
+		desc = L["Show a bright line on the moving edge of the cooldown animation."],
+		tristate = false,
+		get = function () return indicator.dbx.drawEdge end,
+		set = function (_, v)
+			indicator.dbx.drawEdge = v or nil
+			self:RefreshIndicator(indicator, "Create")
+		end,
+		hidden= function() return indicator.dbx.disableCooldown end,
+	}
 end
 
 -- Grid2Options:MakeIndicatorCountdownTextOptions()

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -20,7 +20,7 @@ local function Icon_Create(self, parent)
 	Icon:Show()
 	if not self.disableCooldown then
 		local Cooldown = f.Cooldown or CreateFrame("Cooldown", nil, f, "CooldownFrameTemplate")
-		Cooldown:SetDrawEdge(false)
+		Cooldown:SetDrawEdge(self.dbx.drawEdge)
 		Cooldown:SetReverse(self.dbx.reverseCooldown)
 		Cooldown:SetDrawSwipe(self.showSwipe)
 		Cooldown:SetHideCountdownNumbers(not self.showCoolText)

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -227,7 +227,7 @@ local function Icon_Layout(self, parent)
 			cooldown:SetAllPoints()
 			cooldown:SetAlpha(1)
 			cooldown:SetHideCountdownNumbers(not self.showCoolText)
-			cooldown:SetDrawEdge(false)
+			cooldown:SetDrawEdge(self.dbx.drawEdge)
 			cooldown:SetDrawSwipe(self.showSwipe)
 			cooldown:SetReverse(self.dbx.reverseCooldown)
 			if self.showCoolText then


### PR DESCRIPTION
Added an option for setting DrawEdge on and off on icon/icons animations.

on:
<img width="171" height="96" alt="image" src="https://github.com/user-attachments/assets/9c1ad8b3-bd2c-4b1d-bfe0-5a9c5c3355cd" />

off:
<img width="168" height="92" alt="image" src="https://github.com/user-attachments/assets/802411ef-793f-4d81-a4ce-4c4a0e65f268" />

<img width="475" height="94" alt="image" src="https://github.com/user-attachments/assets/195205b2-a5aa-435e-9c1a-81eaea1957a7" />


