### PR TITLE
Add status color option for icon cooldown text

### DIFF
--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -736,6 +736,18 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 		end,
 		hidden= function() return indicator.dbx.enableCooldownText==nil end,
 	}
+	options.ctUseStatusColor = {
+		type = "toggle",
+		order = 142,
+		name = L["Use Status Color"],
+		tristate = false,
+		get = function () return indicator.dbx.ctUseStatusColor end,
+		set = function (_, v)
+			indicator.dbx.ctUseStatusColor = v or nil
+			self:RefreshIndicator(indicator, "Layout")
+		end,
+		hidden = function() return indicator.dbx.enableCooldownText==nil end,
+	}
 	options.ctFontColor = {
 		type = "color",
 		order = 143,
@@ -747,7 +759,7 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 			self:PackColor( r,g,b,a, indicator.dbx, "ctColor" )
 			self:RefreshIndicator(indicator, "Layout" )
 		 end,
-		hidden = function() return indicator.dbx.enableCooldownText==nil end,
+		hidden = function() return indicator.dbx.enableCooldownText==nil or indicator.dbx.ctUseStatusColor end,
 	}
 end
 
@@ -877,7 +889,7 @@ function Grid2Options:MakeIndicatorCooldownColorsOptions(indicator, options)
 			indicator.dbx.ctColorsText = v or nil
 			RefreshColors()
 		end,
-		disabled = function() return indicator.dbx.enableCooldownText==nil and indicator.dbx.ctColorsText==nil end,
+		disabled = function() return indicator.dbx.ctUseStatusColor or (indicator.dbx.enableCooldownText==nil and indicator.dbx.ctColorsText==nil) end,
 	}
 	--[[
 	options.ctColorTargetBar = {

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -46,7 +46,13 @@ local function Icon_ButtonCreate(self, parent, f, filter)
 		f.Cooldown = Cooldown
 		if self.showCoolText then
 			f.coolText = Cooldown:GetCountdownFontString()
-			if filter then f:SetDurationText(f.coolText, self.ctOptions) end
+			if filter then
+				if self.useStatusColorText then
+					f:SetDurationText(f.coolText, filter.cooldownTextOptions)
+				else
+					f:SetDurationText(f.coolText, self.ctOptions)
+				end
+			end
 		end
 	end
 	if not self.disableStack then
@@ -144,7 +150,13 @@ local function Icon_ButtonLayout(self, parent, f, filter, size, level, status)
 	if self.showCoolText then
 		local color, text = self.ctColor, f.coolText
 		text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
-		text:SetTextColor(color.r, color.g, color.b, color.a)
+		if self.useStatusColorText then
+			if status and not (filter and filter.cooldownTextOptions) then
+				text:SetTextColor(status:GetColor())
+			end
+		else
+			text:SetTextColor(color.r, color.g, color.b, color.a)
+		end
 		text:ClearAllPoints()
 		text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 		text:SetMaxLines(1)
@@ -212,6 +224,9 @@ local function Icon_OnUpdate(self, parent, unit, status)
 	Icon:SetVertexColor(status:GetVertexColor(unit))
 	local durObject
 	local r,g,b,a = status:GetColor(unit)
+	if self.useStatusColorText and self.showCoolText then
+		Frame.coolText:SetTextColor(r, g, b, a)
+	end
 	if self.disableIcon then
 		Icon:SetColorTexture(r,g,b)
 	else
@@ -349,6 +364,7 @@ local function Icon_UpdateDB(self)
 	self.showSwipe       = not (dbx.disableCooldown or dbx.disableCooldownAnim)
 	self.showCoolBar     = dbx.enableCooldownBar
 	self.showCoolText    = dbx.enableCooldownText
+	self.useStatusColorText = self.showCoolText and dbx.ctUseStatusColor
 	self.disableCooldown = dbx.disableCooldown and not dbx.enableCooldownText
 	self.disableStack    = dbx.disableStack
 	self.frameLevel      = dbx.level
@@ -394,7 +410,7 @@ local function Icon_UpdateDB(self)
 	-- self.showColorsBorder= dbx.ctColorsBorder
 	-- self.showColorsBar   = dbx.ctColorsBar
 	-- self.needDur = self.showColors or self.showCoolBar
-	if dbx.ctColorsText and dbx.ctColors then
+	if not self.useStatusColorText and dbx.ctColorsText and dbx.ctColors then
 		self.ctColorCurve = self.ctColorCurve or C_CurveUtil.CreateColorCurve()
 		self.ctColorCurve:SetType(Enum.LuaCurveType.Step)
 		self.ctColorCurve:ClearPoints()

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -73,6 +73,9 @@ local function Icon_OnFrameUpdate(f)
 			if showStack then
 				aura.text:SetText( TruncateWhenZero( status:GetCount(unit) or 0 ) )
 			end
+			if self.useStatusColorText then
+				aura.coolText:SetTextColor(status:GetColor(unit))
+			end
 			if showCool then
 				local expiration, duration = status:GetExpirationTime(unit), status:GetDuration(unit)
 				if expiration and duration then
@@ -276,7 +279,7 @@ end
 -- blizzard secret aura containers 12.1+
 -------------------------------------------------------------
 
-local function Icon_SetupButtonB(self, parent, auraContainer, frame, borderOptions, status)
+local function Icon_SetupButtonB(self, parent, auraContainer, frame, borderOptions, cooldownTextOptions, status)
 	-- frame button
 	local iconSize = self.iconSize>1 and self.iconSize or self.iconSize * parent:GetHeight()
 	frame:SetSize(iconSize, iconSize)
@@ -350,12 +353,21 @@ local function Icon_SetupButtonB(self, parent, auraContainer, frame, borderOptio
 			local ctFontSize = self.ctFontSize<1 and self.ctFontSize*iconSize or self.ctFontSize
 			local text = cooldown:GetCountdownFontString()
 			text:SetFont(self.ctFont, ctFontSize, self.ctFontFlags)
-			text:SetTextColor(UnpackColor(self.ctColor))
+			local ctOptions
+			if self.useStatusColorText then
+				ctOptions = cooldownTextOptions
+				if not ctOptions then
+					text:SetTextColor(status:GetColor())
+				end
+			else
+				ctOptions = self.ctOptions
+				text:SetTextColor(UnpackColor(self.ctColor))
+			end
 			text:ClearAllPoints()
 			text:SetPoint(self.ctFontPoint, self.ctFontOffsetX, self.ctFontOffsetY)
 			text:SetMaxLines(1)
 			frame.coolText = text
-			frame:SetDurationText(text, self.ctOptions)
+			frame:SetDurationText(text, ctOptions)
 		else
 			frame.coolText = nil
 			frame:ClearDurationText()
@@ -443,7 +455,7 @@ local function Icon_LayoutB(self, parent)
 				initializeFrame = function(button)
 					if count>0 then count = count -1; return end
 					buttons[#buttons+1] = button
-					Icon_SetupButtonB(self, parent, auraContainer, button, filter.borderOptions, status)
+					Icon_SetupButtonB(self, parent, auraContainer, button, filter.borderOptions, filter.cooldownTextOptions, status)
 				end
 			} )
 			auraContainer:SetAuraGroupLayout(key, self.groupLayout)
@@ -508,6 +520,7 @@ local function Icon_UpdateDB(self)
 	end
 	self.showSwipe       = not (dbx.disableCooldown or dbx.disableCooldownAnim)
 	self.showCoolText    = dbx.enableCooldownText
+	self.useStatusColorText = self.showCoolText and dbx.ctUseStatusColor
 	self.showCooldown    = dbx.enableCooldownText or not dbx.disableCooldown
 	self.showStack       = not dbx.disableStack
 	self.showIcons       = not dbx.disableIcons
@@ -551,7 +564,7 @@ local function Icon_UpdateDB(self)
 	-- self.showColorsText  = dbx.ctColorsText
 	-- self.showColorsBorder= dbx.ctColorsBorder
 	-- self.showColorsBar   = dbx.ctColorsBar
-	if dbx.ctColorsText and dbx.ctColors then
+	if not self.useStatusColorText and dbx.ctColorsText and dbx.ctColors then
 		self.ctColorCurve = self.ctColorCurve or C_CurveUtil.CreateColorCurve()
 		self.ctColorCurve:SetType(Enum.LuaCurveType.Step)
 		self.ctColorCurve:ClearPoints()


### PR DESCRIPTION
Adds a "Use Status Color" option for cooldown text on `icon` and `icons`
indicators. The setting is off by default.

When enabled:

- Non-aura statuses use `status:GetColor()`.
- AuraContainer statuses use the status's existing
  `cooldownTextOptions` when it has remaining/elapsed-time color rules, or the status' default color when it does not.
- The cooldown text color picker is hidden and ignored.
- The "Cooldown Colors → Cooldown Text" setting is hidden and ignored.

When disabled, existing cooldown text behavior is unchanged.

### Limitation: Dispel-type colors

This option does not work with dispel-type debuff coloring. These statuses will use the fallback/default color instead.

Blizzard exposes per-aura dispel-type coloring (Magic/Curse/Disease/Poison/etc.) through the AuraContainer dispel-texture
API, but does not expose an equivalent binding for a duration FontString.

### Motivation

Due to restrictions in 12.1, text indicators no longer support aura statuses: see https://github.com/michaelnpsp/Grid2/issues/434. As a [workaround](https://github.com/michaelnpsp/Grid2/issues/434#issuecomment-5273137421), icon/icons indicators can be used with the icon hidden; the cooldown text on this indicator behaves similarly to the old text indicators, but without inheriting the color from the status. This patch closes that gap.

Without this patch, to achieve the desired coloring behavior, we would have to mirror status colors into the "Cooldown Colors -> Cooldown Text" setting manually, and limit each indicator to at most one status since the coloring is now indicator-level instead of status-level.