### PR TITLE
Fix icon indicator painting a filled square instead of a border

### DIFF
--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -81,7 +81,9 @@ local function Icon_ButtonCreate(self, parent, f, filter)
 	end
 	if filter then -- border
 		f:ClearAuraBorder()
-		if self.borderSize or self.useStatusColor then
+		-- the border texture covers the whole button and is masked by the icon, so it only
+		-- reads as a border when there is a border size to inset the icon by
+		if self.borderSize then
 			local border = f.border or f:CreateTexture(nil, "BACKGROUND")
 			border:ClearAllPoints()
 			border:SetAllPoints()
@@ -93,8 +95,8 @@ local function Icon_ButtonCreate(self, parent, f, filter)
 			end
 			border:Show()
 			f.border = border
-		elseif self.border then
-			border:Hide()
+		elseif f.border then
+			f.border:Hide()
 		end
 	end
 	if self.showCoolBar then


### PR DESCRIPTION
On `icon` indicators using an AuraContainer status, enabling "Use Status Color" with no
border size and the icon hidden paints the whole button with the status color instead of
drawing a border.

The border texture is created at full size and relies on the icon to mask its center, so
it only reads as a border when there is a border size to inset the icon by:

- With a border size, the icon is inset and the exposed edge is the border.
- With no border size, the icon covers the texture exactly and no border is visible.
- With no border size and `Icon Source = Display Nothing`, nothing masks it and the whole
  button is filled with the border color.

The border texture is now only created when a border size is set, which is what the
`icons` indicator already does.

The cleanup branch also tested `self.border`, which is never assigned, and called `Hide()`
on an undefined global `border`. It was unreachable so it never errored, but it also meant
a border texture was never hidden once created. Aura slot buttons are pooled and reused
between indicators, so a leftover texture could survive until reload. Both are fixed here.

To reproduce: an `icon` indicator with one aura status, `Use Status Color` on,
`Border Size` 0, and `Icon Source = Display Nothing`. The countdown text renders over a
solid status-colored square. This is independent of the cooldown text "Use Status Color"
option added in #437 despite the similar name: it reproduces with that option off, and
with cooldown text disabled entirely.

Not covered: a border size combined with `Icon Source = Display Nothing` still fills the
button rather than drawing a ring, for the same reason. Fixing that needs the nine-slice
border texture `square` indicators use, but `Grid2:GetSliceBorderTexture()` only has
textures for integer sizes 1-7 while `Border Size` has a 0.01 step, so I left it alone.
