### PR TITLE
Fix cooldown text status coloring issues from #437

### DIFF
--- a/Options/locales/enUS.lua
+++ b/Options/locales/enUS.lua
@@ -372,6 +372,7 @@ L["Rectangle"] = true
 L["Allows to independently adjust width and height."] = true
 L["Use Status Color"] = true
 L["Always use the status color for the border"] = true
+L["Color the countdown text with the status color instead of the color below. Statuses that define their own cooldown colors will use those instead."] = true
 
 L["Frame Texture"] = true
 L["Adjust the frame texture."] = true

--- a/Options/modules/indicators/Indicator.lua
+++ b/Options/modules/indicators/Indicator.lua
@@ -740,6 +740,7 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 		type = "toggle",
 		order = 142,
 		name = L["Use Status Color"],
+		desc = L["Color the countdown text with the status color instead of the color below. Statuses that define their own cooldown colors will use those instead."],
 		tristate = false,
 		get = function () return indicator.dbx.ctUseStatusColor end,
 		set = function (_, v)
@@ -759,7 +760,8 @@ function Grid2Options:MakeIndicatorCooldownTextOptions(indicator, options)
 			self:PackColor( r,g,b,a, indicator.dbx, "ctColor" )
 			self:RefreshIndicator(indicator, "Layout" )
 		 end,
-		hidden = function() return indicator.dbx.enableCooldownText==nil or indicator.dbx.ctUseStatusColor end,
+		hidden = function() return indicator.dbx.enableCooldownText==nil end,
+		disabled = function() return indicator.dbx.ctUseStatusColor end,
 	}
 end
 

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -46,13 +46,8 @@ local function Icon_ButtonCreate(self, parent, f, filter)
 		f.Cooldown = Cooldown
 		if self.showCoolText then
 			f.coolText = Cooldown:GetCountdownFontString()
-			if filter then
-				if self.useStatusColorText then
-					f:SetDurationText(f.coolText, filter.cooldownTextOptions)
-				else
-					f:SetDurationText(f.coolText, self.ctOptions)
-				end
-			end
+			-- Icon_UpdateDB() clears ctOptions whenever the status color is used
+			if filter then f:SetDurationText(f.coolText, self.useStatusColorText and filter.cooldownTextOptions or self.ctOptions) end
 		end
 	end
 	if not self.disableStack then
@@ -151,8 +146,11 @@ local function Icon_ButtonLayout(self, parent, f, filter, size, level, status)
 		local color, text = self.ctColor, f.coolText
 		text:SetFont(self.ctFont, self.ctFontSize, self.ctFontFlags)
 		if self.useStatusColorText then
+			-- the status alpha is meant for the icon and border, applying it here can make
+			-- the countdown text unreadable, so only the status hue is used
 			if status and not (filter and filter.cooldownTextOptions) then
-				text:SetTextColor(status:GetColor())
+				local r,g,b = status:GetColor()
+				text:SetTextColor(r, g, b, 1)
 			end
 		else
 			text:SetTextColor(color.r, color.g, color.b, color.a)
@@ -224,8 +222,8 @@ local function Icon_OnUpdate(self, parent, unit, status)
 	Icon:SetVertexColor(status:GetVertexColor(unit))
 	local durObject
 	local r,g,b,a = status:GetColor(unit)
-	if self.useStatusColorText and self.showCoolText then
-		Frame.coolText:SetTextColor(r, g, b, a)
+	if self.useStatusColorText then -- implies showCoolText, see Icon_UpdateDB()
+		Frame.coolText:SetTextColor(r, g, b, 1)
 	end
 	if self.disableIcon then
 		Icon:SetColorTexture(r,g,b)

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -49,6 +49,7 @@ local function Icon_OnFrameUpdate(f)
 	local showBar   = self.showCoolBar
 	local needDur   = showColors or showBar
 	local useStatus = self.useStatusColor
+	local useStatusText = self.useStatusColorText
 	local hideDupes = #self.statuses>1 and self.hideDupes
 	local function checkDupe(slotID)
 		if hideDupes[slotID] then return true end; hideDupes[slotID] = true
@@ -58,23 +59,28 @@ local function Icon_OnFrameUpdate(f)
 		if status:IsActive(unit) then -- TODO secret test maybe
 			local aura = auras[i]
 			aura.status, aura.slotID = status, nil
+			local sr, sg, sb -- status color, fetched once per aura
 			if showIcons then
 				aura.icon:SetTexture(status:GetIcon(unit))
 				aura.icon:SetTexCoord(status:GetTexCoord(unit))
 				aura.icon:SetVertexColor(status:GetVertexColor(unit))
-				if useStatus then
-					local r, g, b, a = status:GetColor(unit)
-					aura:SetBackdropBorderColor(r, g, b, self.borderOpacity)
+				if useStatus or useStatusText then
+					sr, sg, sb = status:GetColor(unit)
+					if useStatus then
+						aura:SetBackdropBorderColor(sr, sg, sb, self.borderOpacity)
+					end
 				end
 			else
-				local r, g, b = status:GetColor(unit)
-				aura.icon:SetColorTexture(r, g, b)
+				sr, sg, sb = status:GetColor(unit)
+				aura.icon:SetColorTexture(sr, sg, sb)
 			end
 			if showStack then
 				aura.text:SetText( TruncateWhenZero( status:GetCount(unit) or 0 ) )
 			end
-			if self.useStatusColorText then
-				aura.coolText:SetTextColor(status:GetColor(unit))
+			-- the status alpha is meant for the icon and border, applying it here can make
+			-- the countdown text unreadable, so only the status hue is used
+			if useStatusText then
+				aura.coolText:SetTextColor(sr, sg, sb, 1)
 			end
 			if showCool then
 				local expiration, duration = status:GetExpirationTime(unit), status:GetDuration(unit)
@@ -356,8 +362,9 @@ local function Icon_SetupButtonB(self, parent, auraContainer, frame, borderOptio
 			local ctOptions
 			if self.useStatusColorText then
 				ctOptions = cooldownTextOptions
-				if not ctOptions then
-					text:SetTextColor(status:GetColor())
+				if not ctOptions then -- no color curve on the status, use its flat color
+					local r,g,b = status:GetColor()
+					text:SetTextColor(r, g, b, 1) -- status alpha would hurt readability
 				end
 			else
 				ctOptions = self.ctOptions


### PR DESCRIPTION
Follow-up to #437. Nothing changes while "Use Status Color" is off.

- The status color alpha was applied to the countdown text. Status colors are configured
  for the icon and border, where a reduced alpha is useful; on the countdown text it only
  makes the text hard to read, and since the color picker was hidden there was no way to
  compensate. The status hue is now used at full alpha.
- The cooldown text color picker is disabled rather than hidden, matching the
  `Cooldown Colors -> Cooldown Text` setting it pairs with. It stays visible and greyed
  out, and the panel no longer reflows when the option is toggled.
- The toggle has a description now. The icon border option is also named
  "Use Status Color", so the two were indistinguishable within the same indicator panel.
  The description covers both behaviors, including that statuses defining their own
  remaining/elapsed-time color rules keep using those.
- `status:GetColor()` was called a second time per aura per update in the `icons` frame
  update, and the flag was read off `self` inside the loop instead of being hoisted with
  the others. The color is now fetched once and reused.
- `Icon_ButtonCreate` branched on the option to choose between the status
  `cooldownTextOptions` and `ctOptions`, but `Icon_UpdateDB` already clears `ctOptions`
  when the status color is in use, so both branches did the same thing.
