### PR TITLE
AuraContainer Flow directions and Centering

### DIFF
--- a/GridUtils.lua
+++ b/GridUtils.lua
@@ -249,6 +249,11 @@ Grid2.AlignPoints= {
 	}
 }
 
+-- flowDirection
+function Grid2.GetFlowDirection(direction)
+	return (direction == "LEFT" and AnchorUtil.FlowDirection.Left) or (direction == "RIGHT" and AnchorUtil.FlowDirection.Right) or (direction == "UP" and AnchorUtil.FlowDirection.Up) or AnchorUtil.FlowDirection.Down
+end
+
 -- Create/Manage/Sets frame backdrops
 do
 	local format = string.format

--- a/Options/GridUtils.lua
+++ b/Options/GridUtils.lua
@@ -84,6 +84,19 @@ Grid2Options.pointValueListExtra2 = {
 	["8"] = L["RIGHT"],
 }
 
+-- Growth directions
+Grid2Options.mapDirectionDefaultToPoint = {
+	["TOPLEFT"] = L["RIGHT"],
+	["LEFT"] = L["RIGHT"],
+	["BOTTOMLEFT"] = L["RIGHT"],
+	["TOP"] = L["DOWN"],
+	["CENTER"] = L["CENTER"],
+	["BOTTOM"] = L["UP"],
+	["TOPRIGHT"] = L["LEFT"],
+	["RIGHT"] = L["LEFT"],
+	["BOTTOMRIGHT"] = L["LEFT"],
+}
+
 -- Font Flags and Shadow
 do
 	local soft   = L["Soft"]

--- a/Options/modules/indicators/IndicatorIcons.lua
+++ b/Options/modules/indicators/IndicatorIcons.lua
@@ -1,17 +1,6 @@
 local media = LibStub("LibSharedMedia-3.0", true)
 local L = Grid2Options.L
 
-local FixSmartCenter
-do
-	local SMARTCENTER_POINTS = { LEFT = true, TOP = true, CENTER = true, BOTTOM = true, RIGHT = true }
-	function FixSmartCenter(indicator)
-		if not (indicator.maxRows==1 and SMARTCENTER_POINTS[indicator.anchorRel]) then
-			indicator.dbx.smartCenter = nil
-			return true
-		end
-	end
-end
-
 Grid2Options:RegisterIndicatorOptions("icons", true, function(self, indicator)
 	local statuses, options, filter =  {}, {}, {}
 	self:MakeIndicatorTypeLevelOptions(indicator,options)
@@ -163,21 +152,25 @@ function Grid2Options:MakeIndicatorAuraIconsSizeOptions(indicator, options, opti
 			self:RefreshIndicator(indicator, "Layout")
 		end,
 	}
-	options.smartCenter = {
-		type = "toggle",
-		name = L["Smart Center Align"],
-		desc = L["Dinamically center the visible icons. Not available for multi-row configurations."],
+	options.growthDirection = {
+		type = "select",
 		order = 18,
-		tristate = false,
+		name = L["Growth Direction"],
+		desc = L["Set the icons growth direction."],
 		get = function ()
-			FixSmartCenter(indicator)
-			return indicator.dbx.smartCenter
+			-- fixing the growth direction when the location point has changed
+			if(indicator.dbx.growthDirectionLocationPointCache ~= indicator.dbx.location.point) then
+				indicator.dbx.growthDirection = Grid2Options.mapDirectionDefaultToPoint[indicator.dbx.location.point]
+				self:RefreshIndicator(indicator, "Layout")
+			end
+			return indicator.dbx.growthDirection
 		end,
 		set = function (_, v)
-			indicator.dbx.smartCenter = v or nil
+			indicator.dbx.growthDirection = v
+			indicator.dbx.growthDirectionLocationPointCache = indicator.dbx.location.point
 			self:RefreshIndicator(indicator, "Layout")
 		end,
-		disabled = function() return FixSmartCenter(indicator) end,
+		values={ UP = L["UP"], DOWN = L["DOWN"], LEFT = L["LEFT"], RIGHT = L["RIGHT"], CENTER = L["CENTER"] }
 	}
 	options.disableIcons = {
 		type = "toggle",

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -13,6 +13,7 @@ local canaccessvalue = Grid2.canaccessvalue
 local TruncateWhenZero = C_StringUtil.TruncateWhenZero
 local UpdateIconColorCurve = Grid2.UpdateIconColorCurve
 local RemoveIconColorCurve = Grid2.RemoveIconColorCurve
+local GetFlowDirection = Grid2.GetFlowDirection
 
 -------------------------------------------------------------
 -- helps functions to disable old mode when mode switches
@@ -426,23 +427,57 @@ local function Icon_LayoutB(self, parent)
 	f:SetFrameLevel(parent:GetFrameLevel() + self.frameLevel)
 	local iconSize = self.iconSize>1 and self.iconSize or self.iconSize * parent:GetHeight()
 	local size = iconSize + self.iconSpacing
-	if size>0 then
-		f:SetSize( size*self.pw+1, size*self.ph+1 )
-	else
-		f:SetSize( iconSize, iconSize ) -- to avoid 0 size frame when using a negative spacing: iconSize+iconSpacing==0
+	-- to avoid 0 size frame when using a negative spacing (iconSize+iconSpacing==0) check if size>0, otherwise use iconSize as a fallback
+	local sizeHorizontal = ((size>0) and size*self.pw or iconSize) + size * 0.5 -- add headroom to avoid icon wrapping early
+	local sizeVertical = (size>0) and size or iconSize
+	if self.vertical then
+		sizeHorizontal, sizeVertical = sizeVertical, sizeHorizontal
 	end
+	f:SetSize( sizeHorizontal, sizeVertical )
 	f:Show()
 	-- bliz aura container
 	Icon_DisableAuraContainer(self, parent, f)
 	local auraContainer = self:AcquireAuraContainer(parent, self.auraContainerKey, f)
 	auraContainer._buttons = {}
 	auraContainer:ClearAllPoints()
-	auraContainer:SetAllPoints()
+	local anchorPositionTop = self.anchorRel:find("TOP", 1, true)
+	local anchorPositionBottom = self.anchorRel:find("BOTTOM", 1, true)
+	local anchorPositionRight = self.anchorRel:find("RIGHT", 1, true)
+	local anchorPositionLeft = self.anchorRel:find("LEFT", 1, true)
+
+	local offsetX, offsetY = self.offsetx, self.offsety
+	local flowDirectionH, flowDirectionV = "RIGHT", "UP"
+
+	if self.growthDirection == "CENTER" then
+		-- couldnt decide if left and right positions should be offset or not, so i left it commented out for now
+		--offsetX = (((anchorPositionLeft) and (iconSize/2) or (anchorPositionRight and (-iconSize/2))) or 0) + offsetX
+		auraContainer:SetPoint((anchorPositionTop and "TOP") or (anchorPositionBottom and "BOTTOM") or "CENTER", parent, self.anchorRel, offsetX, offsetY)
+		flowDirectionV = anchorPositionBottom and "UP" or "DOWN"
+		auraContainer:SetFlowLayoutAnchorPoint ((flowDirectionV == "UP") and "BOTTOMLEFT" or "TOPLEFT")
+	else
+		flowDirectionH = (self.growthDirection == "LEFT") and "LEFT" or "RIGHT"
+		flowDirectionV = (self.growthDirection == "UP") and "UP" or "DOWN"
+
+		local iconOffSetY = (anchorPositionTop and 0) or (anchorPositionBottom and iconSize) or iconSize / 2
+		local iconOffSetX = (anchorPositionLeft and 0) or (anchorPositionRight and iconSize) or iconSize / 2
+
+		if self.growthDirection == "LEFT" or self.growthDirection == "RIGHT" then
+			offsetX = ((self.growthDirection == "LEFT") and (iconSize - iconOffSetX) or -iconOffSetX) + offsetX
+			offsetY = ((not anchorPositionTop and not anchorPositionBottom) and (iconSize / 2) or 0) + offsetY
+			flowDirectionV = anchorPositionBottom and "UP" or "DOWN"
+		else
+			offsetX = ((not anchorPositionRight and not anchorPositionLeft) and (iconOffSetX - iconSize) or 0) + offsetX
+			offsetY = ((self.growthDirection == "UP") and (iconOffSetY - iconSize) or iconOffSetY) + offsetY
+			flowDirectionH = anchorPositionRight and "LEFT" or "RIGHT"
+		end
+		local anchorPoint = ((flowDirectionV == "UP") and "BOTTOM" or "TOP") .. ((flowDirectionH == "LEFT") and "RIGHT" or "LEFT")
+		auraContainer:SetPoint(anchorPoint, parent, self.anchorRel, offsetX, offsetY)
+		auraContainer:SetFlowLayoutAnchorPoint(anchorPoint)
+	end
 	-- auraContainer:SetSize(f:GetSize())
 	auraContainer:SetFlowLayoutAxis(self.layoutAxis)
 	auraContainer:SetFlowLayoutMaximumLineSize( self.vertical and f:GetHeight() or f:GetWidth() )
-	auraContainer:SetFlowLayoutAnchorPoint(self.anchorIcon)
-	auraContainer:SetFlowLayoutGrowthDirection(self.horizontalDirection, self.verticalDirection)
+	auraContainer:SetFlowLayoutGrowthDirection(GetFlowDirection(flowDirectionH), GetFlowDirection(flowDirectionV))
 	auraContainer:SetFlowLayoutPadding(0,0,0,0)
 	local buttons = auraContainer._buttons
 	for i, status in ipairs(self.statuses) do
@@ -509,7 +544,7 @@ local function Icon_UpdateDB(self)
 	self.maxIcons       = dbx.maxIcons or 3
 	self.maxIconsPerRow = dbx.maxIconsPerRow or 3
 	self.maxRows        = math.floor(self.maxIcons/self.maxIconsPerRow) + (self.maxIcons%self.maxIconsPerRow==0 and 0 or 1)
-	self.smartCenter    = dbx.smartCenter and self.maxRows==1
+	self.growthDirection= dbx.growthDirection or "RIGHT"
 	self.uy 			= 0
 	self.vx 			= 0
 	self.ux 			= pointsX[self.anchorIcon]

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -428,7 +428,7 @@ local function Icon_LayoutB(self, parent)
 	local iconSize = self.iconSize>1 and self.iconSize or self.iconSize * parent:GetHeight()
 	local size = iconSize + self.iconSpacing
 	-- to avoid 0 size frame when using a negative spacing (iconSize+iconSpacing==0) check if size>0, otherwise use iconSize as a fallback
-	local sizeHorizontal = ((size>0) and size*self.pw or iconSize) + size * 0.5 -- add headroom to avoid icon wrapping early
+	local sizeHorizontal = ((size>0) and ((self.vertical) and size*self.ph or size*self.pw) or iconSize) + size * 0.5 -- add headroom to avoid icon wrapping early
 	local sizeVertical = (size>0) and size or iconSize
 	if self.vertical then
 		sizeHorizontal, sizeVertical = sizeVertical, sizeHorizontal


### PR DESCRIPTION
Added support for growth directions in the Icons indicator based on AuraContainer flow layouts.

Replaced the Smart Centering setting with a new Growth Direction option:
- UP
- DOWN
- LEFT
- RIGHT
- **CENTER** _(Icons dynamically adjust to center)_

The location setting now automatically adjusts to the most logical direction. (I added a variable to cache the location for —not ideal, but it was the best solution I could find.)

<img width="565" height="551" alt="image" src="https://github.com/user-attachments/assets/4b9da13d-6483-487d-b26a-cc398cb0007b" />
<img width="569" height="552" alt="image" src="https://github.com/user-attachments/assets/7cca46ad-6fc0-4dc8-9bd3-e1191ac088c7" />
<img width="575" height="545" alt="image" src="https://github.com/user-attachments/assets/dfb9a436-d2b5-4de3-afe5-dbcbf52888b6" />
<img width="591" height="557" alt="image" src="https://github.com/user-attachments/assets/3d70fe96-5d88-4a18-a7d9-f2cb58d1d5d1" />

