### PR TITLE
Fix aura containers collecting other units' auras

### DIFF
--- a/GridFrame.lua
+++ b/GridFrame.lua
@@ -191,12 +191,18 @@ function GridFramePrototype:UpdateAuraContainers()
 		local unit = self.unit or 'none'
 		local enabled = unit ~= 'none'
 		for _, container in pairs(manager) do
-			if unit ~= container:GetUnit() then
-				container:SetUnit(unit)
-				container:SetShown(enabled)
-				container:SetEnabled(enabled)
+			if enabled then
+				if unit ~= container:GetUnit() then
+					container:SetUnit(unit)
+				else
+					container:UpdateAllAuras()
+				end
+				container:SetShown(true)
+				container:SetEnabled(true)
 			else
-				container:UpdateAllAuras()
+				container:SetEnabled(false)
+				container:SetShown(false)
+				container:SetUnit(unit)
 			end
 		end
 	end

--- a/GridIndicatorAuras.lua
+++ b/GridIndicatorAuras.lua
@@ -38,10 +38,23 @@ end
 
 --=====================================================================
 
+-- a new container is born enabled at unitToken "none", where it collects every unit's auras
+local function BindAuraContainer(container, unit)
+	if unit then
+		container:SetUnit(unit)
+		container:SetShown(true)
+		container:SetEnabled(true)
+	else
+		container:SetEnabled(false)
+		container:SetShown(false)
+	end
+end
+
 function indicator:AcquireAuraContainer(parent, key, frame)
 	local container = parent.__auraManager[key] -- __auraManager declared in GridFrame.lua
 	if not container then
 		container = CreateFrame("AuraContainer", nil, frame or parent, "CustomAuraContainerTemplate")
+		BindAuraContainer(container, parent.unit)
 		parent.__auraManager[key] = container
 	end
 	return container
@@ -69,6 +82,7 @@ local function GetAuraSlotsContainer(parent)
 	local container = parent.__auraManager[0] -- __auraManager declared in GridFrame.lua
 	if not container then
 		container = CreateFrame("AuraContainer", nil, parent, "CustomAuraContainerTemplate")
+		BindAuraContainer(container, parent.unit)
 		container.slotCount = 0
 		container.slotEnabled = {}
 		container.slotDisabled = {}

--- a/GridStatus.lua
+++ b/GridStatus.lua
@@ -116,7 +116,8 @@ function status:RegisterIndicator(indicator, priority, suspended)
 				self:OnEnable()
 				self:EnableLoad()
 			end
-			indicator:StatusChanged(self, priority)
+			-- resolved, not the argument: WakeUpIndicator passes no priority and that reads as a removal
+			indicator:StatusChanged(self, self.priorities[indicator])
 		end
 	end
 end

--- a/Options/modules/statuses/StatusAuras.lua
+++ b/Options/modules/statuses/StatusAuras.lua
@@ -233,14 +233,17 @@ local Filters = {
 	} },
 }
 
+-- keys are AuraContainerSortMethod values, not display order
 local SORT_VALUES = {
-	[0] = L["Unsorted"],
-	[1] = L["Default"],
-	[2] = L["Big Defensive"],
-	[3] = L["Expiration"],
-	[4] = L["Expiration Only"],
-	[5] = L["Name"],
-	[6] = L["Name Only"],
+	[0] = L["Default"],
+	[1] = L["Big Defensive"],
+	[2] = L["Unit Frame Debuff"],
+	[3] = L["Important Only"],
+	[4] = L["Expiration"],
+	[5] = L["Expiration Only"],
+	[6] = L["Name"],
+	[7] = L["Name Only"],
+	[8] = L["Aura Instance ID Only"],
 }
 
 local MAX_AURA_DURATIONS = {


### PR DESCRIPTION
# Fix aura containers collecting other units' auras

Three small fixes in the 12.1 aura container code. The first is the real bug, the other two
turned up while tracking it down.

## Containers were never bound, and an unbound container collects everyone's auras

`Blizzard_AuraContainer.xml` gives every new AuraContainer the KeyValues `enabled=true` and
`unitToken="none"`. It registers no unit events until it has a group or a slot, but once one
is added those registrations go through `RegisterUnitEvent(event, "none")`, and that does not
filter, so the container receives UNIT_AURA for every unit. `ProcessUnitAuraUpdate` adds
whatever arrives, keyed on the event's token, without comparing it to its own unit.

A container sitting at "none" therefore collects auras from everyone nearby. It cannot fill
from `ParseAllAuras`, which queries "none" and gets nothing back, so it fills one aura at a
time from incremental updates and holds them until some unit sends a full update, which
clears the group and starts it over.

This is easy to watch. Create two containers with a HELPFUL group, bind one to "player" and
leave the other at its defaults. The bound one shows your buffs. The other slowly fills with
auras belonging to people around you.

Grid2 never bound the containers it created. `UpdateAuraContainers` is the only binder and
it runs on unit changes, never from the layout that creates them, while `Icon_LayoutB`
releases and rebuilds its container on every layout pass with the parent already shown. The
options relayout paths walk `registeredFrames`, frames with no unit included. Any relayout
stranded live "none" containers until that frame's unit next changed, which may be never.

On raid frames it looks like a block of frames showing the same auras with the same
countdowns, on units that do not have them. The names stay correct, because those come from
`frame.unit`.

Containers are now bound when they are created, to the frame's unit if it has one, otherwise
parked disabled, which suppresses the registration entirely. Binding before the group exists
means the eventual registration picks up the right unit. `UpdateAuraContainers` used to leave
a container alone whenever its token already matched, which is how one sitting at "none" for a
frame with no unit stayed enabled, so the unbound case now disables explicitly.

## auraMode and iconMode go negative when an indicator wakes

`Grid2:WakeUpIndicator` calls `RegisterIndicator(indicator)` with no priority.
`RegisterIndicator` resolves one for its own bookkeeping but passes the raw argument to
`StatusChanged`, which reads it as a direction (`priority and 1 or -1`), so waking decrements
a counter that should rise.

After one theme suspend and wake, an indicator with a single aura status sits at -1. That is
truthy, so `Icon_Layout` still picks the aura path by luck, but linking a second status lands
it on 0, where the counter is cleared and the indicator drops its aura container. Unlinking
instead leaves it truthy with no aura status left, and `Icon_LayoutAura` and `Bar_Layout`
then index a nil filter.

Passes the resolved priority instead.

## The aura sorting options are off by one

`sortRule` is passed straight to `AddAuraGroup` and `AddAuraSlot` as `sortMethod`, but the
option list was keyed one below `AuraContainerSortMethod`. "Default" applied BigDefensive,
"Big Defensive" applied UnitFrameDebuff, "Expiration" applied ImportantOnly, and "Unsorted"
was not a member at all, since 0 is Default. `ValidateSortOptions` accepts any number in
range, so nothing complained.

The keys now match the enum. Values are not migrated, so a status that was configured under
the old labels keeps the comparator it has been using all along and now shows the right name
for it. Anyone who cares which sort they are on will want to re-check the dropdown. The three
bundled profiles are the good case: `debuffs-Relevant` and `buffs-Relevant` carry
`sortRule = 3`, which the old list called "Expiration" and the corrected one calls "Important
Only", and the latter is both what they have always done and a better fit for the name.

UnitFrameDebuff is listed for completeness but sorts as Default here. It compares
`auraData.debuffType`, which `AuraUtil.ProcessAura` only fills in under the ProcessAura
policy, and these containers are left at the default policy of None.

One side effect worth noting: zhCN already carries translations for "Big Defensive",
"Expiration" and "Expiration Only" that were attached to the wrong comparators, and they now
land on the right ones.
