### PR TITLE
Small aura lifecycle fixes

### DIFF
--- a/GridIndicator.lua
+++ b/GridIndicator.lua
@@ -88,6 +88,9 @@ function indicator:DisableAllFrames()
 		for _, frame in next, Grid2Frame.registeredFrames do
 			if GetFrame(self, frame) then
 				Disable(self, frame)
+				if frame.__auraManager then
+					self:ReleaseAuraSlotButton(frame)
+				end
 			end
 		end
 	end

--- a/GridIndicatorAuras.lua
+++ b/GridIndicatorAuras.lua
@@ -134,7 +134,8 @@ function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key)
 end
 
 function indicator:ReleaseAuraSlotButton(parent, key)
-	local container = GetAuraSlotsContainer(parent)
+	local container = parent.__auraManager[0]
+	if not container then return end
 	local buttonKey, prefixKey = GetAuraSlotKey(self, key)
 	local button = container.slotEnabled[buttonKey]
 	if button then

--- a/GridIndicatorAuras.lua
+++ b/GridIndicatorAuras.lua
@@ -148,6 +148,8 @@ function indicator:ReleaseAuraSlotButton(parent, key)
 			button:ClearDispelTypeTextures()
 			button:ClearApplicationCount()
 			button:ClearDurationCooldown()
+			button:ClearDurationText()
+			button:ClearDurationBar()
 			button:ClearApplicationBar()
 		end
 		container:SetAuraSlotFilterString(button.__slotKey, "")

--- a/GridStatusLoad.lua
+++ b/GridStatusLoad.lua
@@ -57,23 +57,60 @@ end
 
 local FilterG_Register, FilterG_Unregister, FilterG_Refresh
 do
-	local indicators = {} -- indicators marked for update
+	local indicators = {} -- indicators marked for update or relayout
 
 	local function RegisterIndicators(self)
 		local method = self.suspended and "UnregisterStatus" or "RegisterStatus"
+		local layout = self.GetAurasFilter ~= nil
 		for indicator, priority in pairs(self.priorities) do -- wakeup/suspend status from linked indicators
 			indicator[method](indicator, self, priority)
-			indicators[indicator] = true
+			indicators[indicator] = indicators[indicator] or false
+			if layout then -- the parent indicator owns the aura slot
+				local owner = Grid2:GetIndicatorByName(indicator.parentName) or indicator
+				indicators[owner] = true
+			end
 		end
 	end
 
+	local combatFrame
+	local pendingLayout = {}
+
+	local function LayoutPendingIndicators()
+		for indicator in next, pendingLayout do
+			if not indicator.suspended then
+				indicator:LayoutAllFrames()
+				indicator:UpdateAllFrames()
+			end
+		end
+		wipe(pendingLayout)
+	end
+
 	local function UpdateMarkedIndicators()
+		if not next(indicators) then return end
+		local combat = InCombatLockdown()
+		for indicator, layout in next, indicators do
+			if layout then
+				if combat then
+					pendingLayout[indicator] = true
+				else
+					indicator:LayoutAllFrames()
+				end
+			end
+		end
 		for frame, unit in next, Grid2Frame.activatedFrames do
 			for indicator in next, indicators do
 				indicator:Update(frame, unit)
 			end
 		end
 		wipe(indicators)
+		if next(pendingLayout) then
+			combatFrame = combatFrame or CreateFrame("Frame")
+			combatFrame:SetScript("OnEvent", function(self)
+				self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+				LayoutPendingIndicators()
+			end)
+			combatFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+		end
 	end
 
 	local function CheckZoneFilter(filter)

--- a/modules/IndicatorIcons.lua
+++ b/modules/IndicatorIcons.lua
@@ -39,6 +39,7 @@ end
 local function Icon_OnFrameUpdate(f)
 	local unit = f.myFrame.unit
 	if not unit then return end
+	if f.auraContainer then return end
 	local self = f.myIndicator
 	local max = self.maxIcons
 	local auras = f.auras


### PR DESCRIPTION
A few more small aura container bugfixes/changes, following up on #443. These mostly resolve issues that could occur when a status loads or a theme changes. Independent apart from 4, which needs 3. Feel free to pick and choose.

1. **Layout indicators when an aura status loads or unloads.** Deferred until out of combat to be safe. A buffs/debuffs status with a class, spec, zone or group type load condition would show nothing once the condition turned on, and keep showing after it turned off, until the next relayout. `UpdateMarkedIndicators` only called `indicator:Update`, but an aura indicator's mode and container groups are decided in `Layout`.

2. **Don't run the icon-mode frame update on an aura-mode frame.** `Icon_Update` already refuses to queue an aura-mode frame; this adds the same check at time of use, so a queued update can't run after a relayout has switched the frame. Extremely rare, but it hides the frame and takes the aura container down with it.

3. **Don't create an aura container when releasing a slot button.** A frame using no aura slots at all could still end up with an `__auraManager[0]` container. Any indicator not in aura mode calls `ReleaseAuraSlotButton` from its own `Layout`, and that looked the container up through `GetAuraSlotsContainer`, which creates one when the frame has none.

4. **Release the aura slot button when an indicator is disabled.** `icon` and `bar-aura` release it in their own `Disable`, other types did not, so their slot stayed filtered and drawing. `DisableAllFrames` now releases it centrally as well, which is a harmless second call for those two.

5. **Clear the duration text and bar when a slot button is pooled.** An icon can end up showing a countdown or a cooldown bar that belongs to a different indicator, still driven by the engine. Buttons pool by indicator type, so a button released by one `icon` indicator goes to the next one that asks, and the release cleared five of the bindings a `CustomAuraButton` carries but not these two.
