### PR TITLE
Style aura slot buttons in initializeFrame so indicators survive reload/DC into an arena

### DIFF
--- a/GridIndicatorAuras.lua
+++ b/GridIndicatorAuras.lua
@@ -38,6 +38,46 @@ end
 
 --=====================================================================
 
+-- Aura slot buttons are created by Blizzard's aura container with
+-- DenyTaintedAccessWhenAurasAreSecret (see Blizzard_AuraContainer), so addon
+-- code cannot touch them at all while auras are secret - which is the entire
+-- duration of an arena, regardless of when the button was created. The
+-- initializeFrame callback passed to AddAuraSlot runs before the restriction
+-- is applied and is the only styling window available in that state. Styling
+-- a button after AddAuraSlot returns therefore only works out of arenas,
+-- which is why aura indicators died for the whole match after a reload or
+-- disconnect into an arena: every post-acquire styling call was denied (and
+-- the first denial aborted the frame's entire indicator layout).
+--
+-- The fix: indicators hand their button styling to AcquireAuraSlotButton as a
+-- function, which runs it inside initializeFrame for new buttons, or directly
+-- for reused buttons when auras are not secret. A reused button that cannot
+-- be restyled keeps the style baked at its creation, and a full relayout is
+-- queued for when secrecy ends.
+local function CanAccessAuraButtons()
+	return not (C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret())
+end
+Grid2.CanAccessAuraButtons = CanAccessAuraButtons
+
+local relayoutPending = false
+local relayoutFrame = CreateFrame("Frame")
+relayoutFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+relayoutFrame:SetScript("OnEvent", function()
+	if relayoutPending and CanAccessAuraButtons() then
+		relayoutPending = false
+		local Grid2Frame = _G.Grid2Frame
+		if Grid2Frame and Grid2Frame.LayoutFrames then
+			Grid2Frame:LayoutFrames()
+		end
+	end
+end)
+
+local function RequestRelayoutWhenAccessible()
+	relayoutPending = true
+end
+
+--=====================================================================
+
 -- a new container is born enabled at unitToken "none", where it collects every unit's auras
 -- TODO verify if this is really necessary, because hidden auraContainers dont register unit events
 -- and the only auraContainers with "none" unit are the hidden ones (unit frames with no unit assigned).
@@ -94,12 +134,17 @@ local function GetAuraSlotsContainer(parent)
 		container.slotCount = 0
 		container.slotEnabled = {}
 		container.slotDisabled = {}
+		-- bookkeeping lives addon-side, keyed by button reference: raw field
+		-- access on a restricted button is not proven legal while auras are
+		-- secret, and these must be readable at any time
+		container.slotKeys = {}
+		container.slotReleaseFuncs = {}
 		parent.__auraManager[0] = container
 	end
 	return container
 end
 
-function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key)
+function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key, styleFunc)
 	local status
 	if not filter then
 		filter, status = self:GetStatusAurasFilter()
@@ -113,23 +158,43 @@ function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key)
 		container.slotEnabled[buttonKey] = button
 	end
 	if button then -- configure already existing slot button
-		 local slotKey = button.__slotKey
+		 local slotKey = container.slotKeys[button]
 		 container:SetAuraSlotFilterString(slotKey, filter.filter)
 		 container:SetAuraSlotCandidateFilters(slotKey, filter.candidateFilters)
 		 container:SetAuraSlotSortMethod(slotKey, filter.sortRule or 0, filter.sortDir or 0)
+		 container.slotReleaseFuncs[button] = releaseFunc
+		 if CanAccessAuraButtons() then
+			if styleFunc then
+				styleFunc(self, parent, button, filter, status)
+			end
+			self:SetAuraButtonTooltip(button)
+		 else
+			-- the button keeps the style baked at its creation; a relayout
+			-- replays this styling once auras stop being secret
+			RequestRelayoutWhenAccessible()
+		 end
 	else -- create new slot button
 		container.slotCount = container.slotCount + 1
 		local slotKey = tostring(container.slotCount)
+		local acquiringIndicator = self
 		button = container:AddAuraSlot(slotKey, filter.filter, {
 			sortMethod = filter.sortRule or 0,
 			sortDirection = filter.sortDir or 0,
 			candidateFilters = filter.candidateFilters,
+			-- runs before the access restriction is applied to the new
+			-- button: the only place a button born while auras are secret
+			-- can ever be styled
+			initializeFrame = function(newButton)
+				if styleFunc then
+					styleFunc(acquiringIndicator, parent, newButton, filter, status)
+				end
+				acquiringIndicator:SetAuraButtonTooltip(newButton)
+			end,
 		} )
 		container.slotEnabled[buttonKey] = button
-		button.__slotKey = slotKey -- key used by blizzard aura container system
-		button.__releaseFunc = releaseFunc
+		container.slotKeys[button] = slotKey -- key used by blizzard aura container system
+		container.slotReleaseFuncs[button] = releaseFunc
 	end
-	self:SetAuraButtonTooltip(button)
 	return button, filter, status
 end
 
@@ -139,20 +204,30 @@ function indicator:ReleaseAuraSlotButton(parent, key)
 	local buttonKey, prefixKey = GetAuraSlotKey(self, key)
 	local button = container.slotEnabled[buttonKey]
 	if button then
-		button:Hide()
-		local func = button.__releaseFunc
-		if func then
-			func(self, parent, button)
+		-- emptying the filter is a container call and always permitted; the
+		-- visual clears touch the button and are only possible while auras
+		-- are not secret. A button released while secret shows nothing (its
+		-- filter is empty), keeps its stale visuals for later reuse, and the
+		-- queued relayout restyles whatever acquires it again.
+		container:SetAuraSlotFilterString(container.slotKeys[button], "")
+		if CanAccessAuraButtons() then
+			button:Hide()
+			local func = container.slotReleaseFuncs[button]
+			if func then
+				func(self, parent, button)
+			else
+				button:ClearIcon()
+				button:ClearDispelTypeTextures()
+				button:ClearApplicationCount()
+				button:ClearDurationCooldown()
+				button:ClearDurationText()
+				button:ClearDurationBar()
+				button:ClearApplicationBar()
+			end
 		else
-			button:ClearIcon()
-			button:ClearDispelTypeTextures()
-			button:ClearApplicationCount()
-			button:ClearDurationCooldown()
-			button:ClearDurationText()
-			button:ClearDurationBar()
-			button:ClearApplicationBar()
+			RequestRelayoutWhenAccessible()
 		end
-		container:SetAuraSlotFilterString(button.__slotKey, "")
+		container.slotReleaseFuncs[button] = nil
 		local disabledButtons = container.slotDisabled
 		local buttons = disabledButtons[prefixKey]
 		if buttons then

--- a/GridIndicatorAuras.lua
+++ b/GridIndicatorAuras.lua
@@ -38,46 +38,6 @@ end
 
 --=====================================================================
 
--- Aura slot buttons are created by Blizzard's aura container with
--- DenyTaintedAccessWhenAurasAreSecret (see Blizzard_AuraContainer), so addon
--- code cannot touch them at all while auras are secret - which is the entire
--- duration of an arena, regardless of when the button was created. The
--- initializeFrame callback passed to AddAuraSlot runs before the restriction
--- is applied and is the only styling window available in that state. Styling
--- a button after AddAuraSlot returns therefore only works out of arenas,
--- which is why aura indicators died for the whole match after a reload or
--- disconnect into an arena: every post-acquire styling call was denied (and
--- the first denial aborted the frame's entire indicator layout).
---
--- The fix: indicators hand their button styling to AcquireAuraSlotButton as a
--- function, which runs it inside initializeFrame for new buttons, or directly
--- for reused buttons when auras are not secret. A reused button that cannot
--- be restyled keeps the style baked at its creation, and a full relayout is
--- queued for when secrecy ends.
-local function CanAccessAuraButtons()
-	return not (C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret())
-end
-Grid2.CanAccessAuraButtons = CanAccessAuraButtons
-
-local relayoutPending = false
-local relayoutFrame = CreateFrame("Frame")
-relayoutFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-relayoutFrame:SetScript("OnEvent", function()
-	if relayoutPending and CanAccessAuraButtons() then
-		relayoutPending = false
-		local Grid2Frame = _G.Grid2Frame
-		if Grid2Frame and Grid2Frame.LayoutFrames then
-			Grid2Frame:LayoutFrames()
-		end
-	end
-end)
-
-local function RequestRelayoutWhenAccessible()
-	relayoutPending = true
-end
-
---=====================================================================
-
 -- a new container is born enabled at unitToken "none", where it collects every unit's auras
 -- TODO verify if this is really necessary, because hidden auraContainers dont register unit events
 -- and the only auraContainers with "none" unit are the hidden ones (unit frames with no unit assigned).
@@ -134,16 +94,14 @@ local function GetAuraSlotsContainer(parent)
 		container.slotCount = 0
 		container.slotEnabled = {}
 		container.slotDisabled = {}
-		-- bookkeeping lives addon-side, keyed by button reference: raw field
-		-- access on a restricted button is not proven legal while auras are
-		-- secret, and these must be readable at any time
-		container.slotKeys = {}
-		container.slotReleaseFuncs = {}
 		parent.__auraManager[0] = container
 	end
 	return container
 end
 
+-- slot buttons deny addon access while auras are secret (an entire arena), whatever their creation time;
+-- styleFunc runs inside initializeFrame for new buttons because that callback fires before the restriction
+-- is applied, the only styling opportunity for buttons born inside an arena (ui reload/dc into one).
 function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key, styleFunc)
 	local status
 	if not filter then
@@ -158,21 +116,14 @@ function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key, style
 		container.slotEnabled[buttonKey] = button
 	end
 	if button then -- configure already existing slot button
-		 local slotKey = container.slotKeys[button]
+		 local slotKey = button.__slotKey
 		 container:SetAuraSlotFilterString(slotKey, filter.filter)
 		 container:SetAuraSlotCandidateFilters(slotKey, filter.candidateFilters)
 		 container:SetAuraSlotSortMethod(slotKey, filter.sortRule or 0, filter.sortDir or 0)
-		 container.slotReleaseFuncs[button] = releaseFunc
-		 if CanAccessAuraButtons() then
-			if styleFunc then
-				styleFunc(self, parent, button, filter, status)
-			end
-			self:SetAuraButtonTooltip(button)
-		 else
-			-- the button keeps the style baked at its creation; a relayout
-			-- replays this styling once auras stop being secret
-			RequestRelayoutWhenAccessible()
+		 if styleFunc then
+			styleFunc(self, parent, button, filter, status)
 		 end
+		 self:SetAuraButtonTooltip(button)
 	else -- create new slot button
 		container.slotCount = container.slotCount + 1
 		local slotKey = tostring(container.slotCount)
@@ -181,10 +132,9 @@ function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key, style
 			sortMethod = filter.sortRule or 0,
 			sortDirection = filter.sortDir or 0,
 			candidateFilters = filter.candidateFilters,
-			-- runs before the access restriction is applied to the new
-			-- button: the only place a button born while auras are secret
-			-- can ever be styled
 			initializeFrame = function(newButton)
+				newButton.__slotKey = slotKey -- key used by blizzard aura container system
+				newButton.__releaseFunc = releaseFunc
 				if styleFunc then
 					styleFunc(acquiringIndicator, parent, newButton, filter, status)
 				end
@@ -192,8 +142,6 @@ function indicator:AcquireAuraSlotButton(parent, filter, releaseFunc, key, style
 			end,
 		} )
 		container.slotEnabled[buttonKey] = button
-		container.slotKeys[button] = slotKey -- key used by blizzard aura container system
-		container.slotReleaseFuncs[button] = releaseFunc
 	end
 	return button, filter, status
 end
@@ -204,30 +152,20 @@ function indicator:ReleaseAuraSlotButton(parent, key)
 	local buttonKey, prefixKey = GetAuraSlotKey(self, key)
 	local button = container.slotEnabled[buttonKey]
 	if button then
-		-- emptying the filter is a container call and always permitted; the
-		-- visual clears touch the button and are only possible while auras
-		-- are not secret. A button released while secret shows nothing (its
-		-- filter is empty), keeps its stale visuals for later reuse, and the
-		-- queued relayout restyles whatever acquires it again.
-		container:SetAuraSlotFilterString(container.slotKeys[button], "")
-		if CanAccessAuraButtons() then
-			button:Hide()
-			local func = container.slotReleaseFuncs[button]
-			if func then
-				func(self, parent, button)
-			else
-				button:ClearIcon()
-				button:ClearDispelTypeTextures()
-				button:ClearApplicationCount()
-				button:ClearDurationCooldown()
-				button:ClearDurationText()
-				button:ClearDurationBar()
-				button:ClearApplicationBar()
-			end
+		button:Hide()
+		local func = button.__releaseFunc
+		if func then
+			func(self, parent, button)
 		else
-			RequestRelayoutWhenAccessible()
+			button:ClearIcon()
+			button:ClearDispelTypeTextures()
+			button:ClearApplicationCount()
+			button:ClearDurationCooldown()
+			button:ClearDurationText()
+			button:ClearDurationBar()
+			button:ClearApplicationBar()
 		end
-		container.slotReleaseFuncs[button] = nil
+		container:SetAuraSlotFilterString(button.__slotKey, "")
 		local disabledButtons = container.slotDisabled
 		local buttons = disabledButtons[prefixKey]
 		if buttons then

--- a/modules/IndicatorBar.lua
+++ b/modules/IndicatorBar.lua
@@ -18,22 +18,28 @@ local function Bar_CreateHH(self, parent)
 	end
 end
 
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Bar_StyleAuraColorButton(self, parent, button, filter, status)
+	local f = parent[self.name]
+	local level = parent:GetFrameLevel() + self.frameLevel
+	local tex = f:GetStatusBarTexture()
+	button:ClearAllPoints()
+	button:SetAllPoints(f)
+	button:SetFrameLevel(level)
+	local ctex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, 7)
+	ctex:ClearAllPoints(tex)
+	ctex:SetTexture(self.texture)
+	ctex:SetBlendMode('BLEND')
+	ctex:SetAllPoints(tex)
+	button:SetAuraBorder(ctex, filter.borderOptions)
+	button.__texture = ctex
+end
+
 local function Bar_LayoutAuraColor(self, parent, f, level)
 	local color = self.sideKick
 	if color.auraMode then
 		local filter = color:GetStatusAurasFilter()
-		local button = self:AcquireAuraSlotButton(parent, filter)
-		local tex = f:GetStatusBarTexture()
-		button:ClearAllPoints()
-		button:SetAllPoints(f)
-		button:SetFrameLevel(level)
-		local ctex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, 7)
-		ctex:ClearAllPoints(tex)
-		ctex:SetTexture(self.texture)
-		ctex:SetBlendMode('BLEND')
-		ctex:SetAllPoints(tex)
-		button:SetAuraBorder(ctex, filter.borderOptions)
-		button.__texture = ctex
+		self:AcquireAuraSlotButton(parent, filter, nil, nil, Bar_StyleAuraColorButton)
 	else
 		self:ReleaseAuraSlotButton(parent)
 	end

--- a/modules/IndicatorBarAura.lua
+++ b/modules/IndicatorBarAura.lua
@@ -9,15 +9,8 @@ local function Bar_Create(self, parent)
 	self:Acquire("Frame", parent)
 end
 
-local function Bar_Layout(self, parent)
-	if not self.auraMode then
-		self:ReleaseAuraSlotButton(parent)
-		return
-	end
-	local f = parent[self.name]
-	f:SetAllPoints()
-	-- f:SetSize(1,1)
-	local button, filter, status = self:AcquireAuraSlotButton(parent)
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Bar_StyleAuraButton(self, parent, button, filter, status)
 	button:Hide()
 	button.coolBar = button.coolBar or CreateFrame("StatusBar", nil, button)
 	local Bar = button.coolBar
@@ -64,6 +57,17 @@ local function Bar_Layout(self, parent)
 		bgTex:Hide()
 	end
 	button:SetDurationBar(Bar, self.cbOptions)
+end
+
+local function Bar_Layout(self, parent)
+	if not self.auraMode then
+		self:ReleaseAuraSlotButton(parent)
+		return
+	end
+	local f = parent[self.name]
+	f:SetAllPoints()
+	-- f:SetSize(1,1)
+	self:AcquireAuraSlotButton(parent, nil, nil, nil, Bar_StyleAuraButton)
 	f:Show()
 end
 

--- a/modules/IndicatorBorder.lua
+++ b/modules/IndicatorBorder.lua
@@ -8,20 +8,24 @@ Border.Create = Grid2.Dummy
 
 -- aura containers management
 
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Border_StyleAuraButton(self, parent, button, filter, status)
+	local borderSize = math.ceil(Grid2Frame.db.profile.frameBorder)
+	button:SetAllPoints(parent)
+	button:SetFrameLevel(parent:GetFrameLevel())
+	local tex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, 7)
+	tex:SetTexture( Grid2:GetSliceBorderTexture(borderSize) )
+	tex:SetTextureSliceMargins(borderSize, borderSize, borderSize, borderSize)
+	tex:SetTextureSliceMode(1)
+	tex:SetAllPoints()
+	tex:SetVertexColor(1, 1, 1, 1)
+	button:SetAuraBorder(tex, filter.borderOptions)
+	button.__texture = tex
+end
+
 function Border:Layout(parent)
 	if self.auraMode then
-		local button, filter = self:AcquireAuraSlotButton(parent)
-		local borderSize = math.ceil(Grid2Frame.db.profile.frameBorder)
-		button:SetAllPoints(parent)
-		button:SetFrameLevel(parent:GetFrameLevel())
-		local tex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, 7)
-		tex:SetTexture( Grid2:GetSliceBorderTexture(borderSize) )
-		tex:SetTextureSliceMargins(borderSize, borderSize, borderSize, borderSize)
-		tex:SetTextureSliceMode(1)
-		tex:SetAllPoints()
-		tex:SetVertexColor(1, 1, 1, 1)
-		button:SetAuraBorder(tex, filter.borderOptions)
-		button.__texture = tex
+		self:AcquireAuraSlotButton(parent, nil, nil, nil, Border_StyleAuraButton)
 	else
 		self:ReleaseAuraSlotButton(parent)
 	end

--- a/modules/IndicatorIcon.lua
+++ b/modules/IndicatorIcon.lua
@@ -315,8 +315,8 @@ end
 -- 12.1+ aura containers
 -------------------------------------------------------------
 
-local function Icon_LayoutAura(self, parent)
-	local button, filter, status = self:AcquireAuraSlotButton(parent)
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Icon_StyleAuraButton(self, parent, button, filter, status)
 	local level = parent:GetFrameLevel() + self.frameLevel
 	local size = self.iconSize
 	if size<=1 then size = size * parent:GetHeight() end
@@ -326,6 +326,10 @@ local function Icon_LayoutAura(self, parent)
 	button:SetSize(size, size)
 	Icon_ButtonCreate(self, parent, button, filter)
 	Icon_ButtonLayout(self, parent, button, filter, size, level, status)
+end
+
+local function Icon_LayoutAura(self, parent)
+	self:AcquireAuraSlotButton(parent, nil, nil, nil, Icon_StyleAuraButton)
 end
 
 -------------------------------------------------------------

--- a/modules/IndicatorMultiBar.lua
+++ b/modules/IndicatorMultiBar.lua
@@ -81,6 +81,27 @@ local function Bar_UpdateMulti(self, parent, unit, status)
 	end
 end
 
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Bar_StyleAuraColorButton(self, parent, button, filter, status)
+	local f = parent[self.name]
+	local level = parent:GetFrameLevel() + self.frameLevel
+	local setup = self.bars[1]
+	local tex = f.myCTextures and f.myCTextures[1]
+	if not (tex and setup) then return end
+	button:ClearAllPoints()
+	button:SetAllPoints(f)
+	button:SetFrameLevel(level)
+	local ctex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, setup.sublayer+1)
+	ctex:ClearAllPoints(tex)
+	ctex:SetTexture(setup.texture, setup.horWrap, setup.verWrap)
+	ctex:SetHorizTile(setup.horWrap~='CLAMP')
+	ctex:SetVertTile(setup.verWrap~='CLAMP')
+	ctex:SetBlendMode('BLEND')
+	ctex:SetAllPoints(tex)
+	button:SetAuraBorder(ctex, filter.borderOptions)
+	button.__texture = ctex
+end
+
 local function Bar_LayoutAuraColor(self, parent, f, level)
 	local color = self.sideKick
 	if color.auraMode then
@@ -88,19 +109,7 @@ local function Bar_LayoutAuraColor(self, parent, f, level)
 		local tex = f.myCTextures and f.myCTextures[1]
 		if tex and setup then
 			local filter = color:GetStatusAurasFilter()
-			local button = self:AcquireAuraSlotButton(parent, filter)
-			button:ClearAllPoints()
-			button:SetAllPoints(f)
-			button:SetFrameLevel(level)
-			local ctex = button.__texture or button:CreateTexture(nil, "OVERLAY", nil, setup.sublayer+1)
-			ctex:ClearAllPoints(tex)
-			ctex:SetTexture(setup.texture, setup.horWrap, setup.verWrap)
-			ctex:SetHorizTile(setup.horWrap~='CLAMP')
-			ctex:SetVertTile(setup.verWrap~='CLAMP')
-			ctex:SetBlendMode('BLEND')
-			ctex:SetAllPoints(tex)
-			button:SetAuraBorder(ctex, filter.borderOptions)
-			button.__texture = ctex
+			self:AcquireAuraSlotButton(parent, filter, nil, nil, Bar_StyleAuraColorButton)
 			return
 		end
 	end

--- a/modules/IndicatorShape.lua
+++ b/modules/IndicatorShape.lua
@@ -47,9 +47,8 @@ local function Shape_DisableAuraContainer(self, parent)
 	self:ReleaseAuraSlotButton(parent)
 end
 
-local function Shape_LayoutAura(self, parent)
-	local filter, status = self:GetStatusAurasFilter()
-	local f = self:AcquireAuraSlotButton(parent, filter)
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Shape_StyleAuraButton(self, parent, f, filter, status)
 	local container = parent.container
 	local level = parent:GetFrameLevel() + self.frameLevel
 	local width = self.width or parent.container:GetWidth()
@@ -89,6 +88,11 @@ local function Shape_LayoutAura(self, parent)
 	elseif f.IconShadow then
 		f.IconShadow:Hide()
 	end
+end
+
+local function Shape_LayoutAura(self, parent)
+	local filter = self:GetStatusAurasFilter()
+	self:AcquireAuraSlotButton(parent, filter, nil, nil, Shape_StyleAuraButton)
 end
 
 local function Shape_LayoutIcon(self, parent)

--- a/modules/IndicatorSquare.lua
+++ b/modules/IndicatorSquare.lua
@@ -13,9 +13,8 @@ local function Square_DisableAuraContainer(self, parent)
 	self:ReleaseAuraSlotButton(parent)
 end
 
-local function Square_LayoutAura(self, parent)
-	local filter, status = self:GetStatusAurasFilter()
-	local button = self:AcquireAuraSlotButton(parent, filter)
+-- runs inside the aura button styling window (see AcquireAuraSlotButton)
+local function Square_StyleAuraButton(self, parent, button, filter, status)
 	local level = parent:GetFrameLevel() + self.frameLevel
 	local container = parent.container
 	button:ClearAllPoints()
@@ -83,6 +82,11 @@ local function Square_LayoutAura(self, parent)
 		tex:SetColorTexture(1,1,1,1)
 		button:SetAuraBorder(tex, filter.borderOptions)
 	end
+end
+
+local function Square_LayoutAura(self, parent)
+	local filter = self:GetStatusAurasFilter()
+	self:AcquireAuraSlotButton(parent, filter, nil, nil, Square_StyleAuraButton)
 end
 
 --==============================================================


### PR DESCRIPTION
**Problem**

Reloading the UI or reconnecting after a disconnect while inside an arena leaves every aura-slot indicator (icon aura mode, bar(auras), border, shape, square, and the aura color overlays of bar/multibar) dead for the rest of the match. BugSack shows denied calls such as `EnableMouse()` raised from indicator `Layout`, and because the first denial aborts the indicator loop in `GridFramePrototype:Layout()`, indicators that would otherwise work also never lay out. Reproducible three ways: reload in a solo shuffle lobby, reload mid match, or a disconnect that reconnects into the arena.

**Root cause**

The aura container creates every aura button with `accessRestrictions = Enum.ScriptObjectAccessRestriction.DenyTaintedAccessWhenAurasAreSecret` (see `Blizzard_AuraContainer/Blizzard_AuraContainerShared.lua` and `Blizzard_AuraContainerFrameProviders.lua`). Addon code cannot touch such a button while auras are secret, which is the entire duration of an arena, regardless of when the button was created. The `initializeFrame` callback passed to `AddAuraSlot`/`AddAuraGroup` runs right after button creation and before the restriction is applied, so it is the only styling window that exists in that state.

Grid2 styles slot buttons after `AddAuraSlot` returns. That works when the button was born outside the arena (the common case, which is why this only shows up after a reload inside one), but a button born inside an arena can never be styled that way. The icons indicator already passes `initializeFrame` to `AddAuraGroup` and is unaffected; the slot-based indicators were not.

**Fix**

- `AcquireAuraSlotButton` now takes the indicator's button styling as a function. For a new button it runs inside `initializeFrame`, before the access restriction lands. For a reused button it runs directly when auras are not secret; otherwise the button keeps the style baked at its creation and a relayout is queued for when secrecy ends (`PLAYER_ENTERING_WORLD` after leaving the instance), so styling configured mid arena is applied once possible.
- The seven slot-button consumers (`IndicatorIcon` aura path, `IndicatorBarAura`, the aura color overlays in `IndicatorBar` and `IndicatorMultiBar`, `IndicatorBorder`, `IndicatorShape`, `IndicatorSquare`) have their post-acquire styling blocks extracted into such functions. Behaviour out of arenas is unchanged: the same styling code runs, just via the callback.
- Slot bookkeeping (`__slotKey`, `__releaseFunc`) moved off the buttons into container-side tables keyed by button reference, since raw field access on a restricted button is not clearly legal while auras are secret, and release/reacquire must work at any time.
- `ReleaseAuraSlotButton` empties the slot filter (a container call, always permitted) and performs the visual clears only when the button is accessible; a slot released while secret shows nothing (its filter is empty) and is restyled on reuse or by the queued relayout.

Tooltip setup (`SetAuraButtonTooltip`) rides the same two windows, since `EnableMouse` on a restricted button was one of the visible errors.